### PR TITLE
fix: update repository URLs to fg-labs after org transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Type-validated Python models for delimited data files.
 
-[![CI](https://github.com/fulcrumgenomics/fgmetric/actions/workflows/python_package.yml/badge.svg?branch=main)](https://github.com/fulcrumgenomics/fgmetric/actions/workflows/python_package.yml?query=branch%3Amain)
-[![Python Versions](https://img.shields.io/badge/python-3.12_|_3.13-blue)](https://github.com/fulcrumgenomics/fgmetric)
+[![CI](https://github.com/fg-labs/fgmetric/actions/workflows/python_package.yml/badge.svg?branch=main)](https://github.com/fg-labs/fgmetric/actions/workflows/python_package.yml?query=branch%3Amain)
+[![Python Versions](https://img.shields.io/badge/python-3.12_|_3.13-blue)](https://github.com/fg-labs/fgmetric)
 [![MyPy Checked](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://docs.astral.sh/ruff/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ classifiers     = [
 ]
 
 [project.urls]
-"homepage" = "https://github.com/fulcrumgenomics/fgmetric"
-"repository" = "https://github.com/fulcrumgenomics/fgmetric"
-"Bug Tracker" = "https://github.com/fulcrumgenomics/fgmetric/issues"
+"homepage" = "https://github.com/fg-labs/fgmetric"
+"repository" = "https://github.com/fg-labs/fgmetric"
+"Bug Tracker" = "https://github.com/fg-labs/fgmetric/issues"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

- Update `pyproject.toml` `[project.urls]` (`homepage`, `repository`, `Bug Tracker`) from `fulcrumgenomics/fgmetric` → `fg-labs/fgmetric`
- Update README badges (CI status, Python Versions) to point at the new org

Author metadata (`Fulcrum Genomics LLC <contact@fulcrumgenomics.com>`) references the company and is intentionally unchanged.

This PR is independent of the PyPI Trusted Publisher migration on the publishing side — it only updates GitHub-side metadata.

## Test plan

- [x] No functional code changes; existing CI covers the package
- [ ] After release, the crates/PyPI listing reflects the new repository URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository references across the project. This includes badge links in README documentation (CI and Python versions badges), as well as project metadata configuration for homepage, repository, and bug tracker URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->