### PR TITLE
feat: Add `NullSentinels` mixin for Optional-field null handling

### DIFF
--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -1,21 +1,21 @@
 from abc import ABC
 from csv import DictReader
 from pathlib import Path
-from typing import Any
+from typing import ClassVar
 from typing import Iterator
 from typing import Self
 
 from pydantic import BaseModel
-from pydantic import model_validator
 
-from fgmetric._typing_extensions import is_optional
 from fgmetric.collections import CounterPivotTable
 from fgmetric.collections import DelimitedList
+from fgmetric.mixins import NullSentinels
 
 
 class Metric(
     DelimitedList,
     CounterPivotTable,
+    NullSentinels,
     BaseModel,
     ABC,
 ):
@@ -32,8 +32,9 @@ class Metric(
     header of the file. Subclasses should define their fields using Pydantic field annotations.
 
     `Metric` includes the following custom serialization/deserialization behaviors:
-    1. **Empty fields as None.** Any empty field in a file will be represented as `None` on the
-       deserialized model.
+    1. **Null sentinels.** Input strings in the `null_sentinels` class variable are treated as
+       `None` on Optional fields before field validation. Defaults to `frozenset({""})`, so any
+       empty Optional field is represented as `None` on the deserialized model.
     2. **Delimited lists.** Any field typed as `list[T]` will be parsed from and serialized to a
        delimited string. The list delimiter may be controlled by the `collection_delimiter` class
        variable.
@@ -41,6 +42,8 @@ class Metric(
     Class Variables:
         collection_delimiter: A single-character delimiter used to split and join `list` fields
             during serialization/deserialization.
+        null_sentinels: The set of input strings that should be treated as `None` on Optional
+            fields during validation. Defaults to `frozenset({""})`.
 
     Example:
         ```python
@@ -54,6 +57,8 @@ class Metric(
             print(metric.read_name, metric.mapping_quality)
         ```
     """
+
+    null_sentinels: ClassVar[frozenset[str]] = frozenset({""})
 
     @classmethod
     def read(cls, path: Path, delimiter: str = "\t") -> Iterator[Self]:
@@ -70,35 +75,6 @@ class Metric(
         with path.open(encoding="utf-8-sig") as fin:
             for record in DictReader(fin, delimiter=delimiter):
                 yield cls.model_validate(record)
-
-    # NB: "Before" validators (mode="before") run before field validators such as
-    # `DelimitedList._split_lists()`. Empty strings in Optional fields will always be converted to
-    # `None` before any field validators.
-    # For example, for delimited list parsing:
-    #   - When a field is defined as `list[T] | None`, this converts "" → None before _split_lists
-    #     sees it.
-    #   - When a field is defined as `list[T]`, "" passes through unchanged, then _split_lists
-    #     converts "" → [].
-    @model_validator(mode="before")
-    @classmethod
-    def _empty_field_to_none(cls, data: Any) -> Any:
-        """Treat any empty fields as None if the field is typed as Optional."""
-        if not isinstance(data, dict):
-            # short circuit
-            return data
-
-        data = dict(data)
-
-        for field, value in data.items():
-            info = cls.model_fields.get(field)
-            if info is None:
-                # Skip fields that aren't defined on the model - let the validation handle it
-                continue
-
-            if value == "" and is_optional(info.annotation):
-                data[field] = None
-
-        return data
 
     @classmethod
     def _header_fieldnames(cls) -> list[str]:

--- a/fgmetric/mixins/__init__.py
+++ b/fgmetric/mixins/__init__.py
@@ -1,0 +1,5 @@
+from fgmetric.mixins._null_sentinels import NullSentinels
+
+__all__ = [
+    "NullSentinels",
+]

--- a/fgmetric/mixins/_null_sentinels.py
+++ b/fgmetric/mixins/_null_sentinels.py
@@ -1,0 +1,84 @@
+from typing import Any
+from typing import ClassVar
+from typing import final
+
+from pydantic import BaseModel
+from pydantic import model_validator
+
+from fgmetric._typing_extensions import is_optional
+
+
+# NB: Inheriting from BaseModel is necessary to declare model validators on the mixin, and for the
+# class-level initialization in `__pydantic_init_subclass__` to work.
+class NullSentinels(BaseModel):
+    """
+    Treat configured input strings as null on Optional fields.
+
+    When this mixin is added to a model, the `null_sentinels` class variable declares the set of
+    input strings that represent null. Any field annotated as `T | None` whose incoming value is
+    one of the configured sentinels will be substituted with `None` before downstream field
+    validators run.
+
+    The substitution is scoped to Optional fields. Non-Optional fields are not touched, which
+    keeps this mixin composable with field-specific handling (e.g., `DelimitedList`'s treatment
+    of `list[T]` fields).
+
+    Class Variables:
+        null_sentinels: The set of input strings that should be treated as null on Optional
+            fields. Defaults to an empty set (no substitution).
+
+    Examples:
+        Treat empty strings as null:
+
+        ```python
+        class MyMetric(Metric):
+            null_sentinels = frozenset({""})
+            name: str
+            count: int | None
+
+        MyMetric.model_validate({"name": "foo", "count": ""}).count  # -> None
+        ```
+
+        Treat multiple sentinels as null:
+
+        ```python
+        class MyMetric(Metric):
+            null_sentinels = frozenset({"", "NA"})
+            count: int | None
+
+        MyMetric.model_validate({"count": "NA"}).count  # -> None
+        ```
+    """
+
+    null_sentinels: ClassVar[frozenset[str]] = frozenset()
+    _optional_fieldnames: ClassVar[set[str]]
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+        """Record the names of Optional-typed fields for use in null-sentinel substitution."""
+        super().__pydantic_init_subclass__(**kwargs)
+        cls._optional_fieldnames = {
+            name for name, info in cls.model_fields.items() if is_optional(info.annotation)
+        }
+
+    @final
+    @model_validator(mode="before")
+    @classmethod
+    def _substitute_null_sentinels(cls, data: Any) -> Any:
+        """Substitute incoming sentinel strings on Optional fields with `None`."""
+        if not cls.null_sentinels:
+            return data
+
+        if not isinstance(data, dict):
+            return data
+
+        data = dict(data)
+
+        for field in cls._optional_fieldnames:
+            if field not in data:
+                continue
+            value = data[field]
+            if isinstance(value, str) and value in cls.null_sentinels:
+                data[field] = None
+
+        return data

--- a/tests/test_null_sentinels.py
+++ b/tests/test_null_sentinels.py
@@ -1,0 +1,121 @@
+from typing import ClassVar
+
+import pytest
+from pydantic import ConfigDict
+from pydantic import ValidationError
+
+from fgmetric.mixins import NullSentinels
+
+
+def test_default_does_not_substitute() -> None:
+    """Default `null_sentinels = frozenset()` means no substitution happens."""
+
+    class Model(NullSentinels):
+        name: str
+        value: str | None
+
+    result = Model.model_validate({"name": "foo", "value": ""})
+    assert result.value == ""
+
+
+def test_empty_string_treated_as_null() -> None:
+    """Empty strings become None on Optional fields when `""` is a configured sentinel."""
+
+    class Model(NullSentinels):
+        null_sentinels: ClassVar[frozenset[str]] = frozenset({""})
+
+        name: str
+        value: int | None
+
+    result = Model.model_validate({"name": "foo", "value": ""})
+    assert result.value is None
+
+
+def test_non_optional_fields_are_not_substituted() -> None:
+    """Non-Optional fields are not touched even when their input matches a sentinel."""
+
+    class Model(NullSentinels):
+        null_sentinels: ClassVar[frozenset[str]] = frozenset({"NA"})
+
+        name: str
+        status: str
+
+    result = Model.model_validate({"name": "foo", "status": "NA"})
+    assert result.status == "NA"
+
+
+def test_arbitrary_sentinels_are_supported() -> None:
+    """Sentinels other than `""` work, provided the field is Optional."""
+
+    class Model(NullSentinels):
+        null_sentinels: ClassVar[frozenset[str]] = frozenset({"NA"})
+
+        status: str | None
+
+    result = Model.model_validate({"status": "NA"})
+    assert result.status is None
+
+
+def test_multiple_sentinels() -> None:
+    """Multiple strings can be configured as null sentinels."""
+
+    class Model(NullSentinels):
+        null_sentinels: ClassVar[frozenset[str]] = frozenset({"", "NA", "None"})
+
+        value: int | None
+
+    assert Model.model_validate({"value": ""}).value is None
+    assert Model.model_validate({"value": "NA"}).value is None
+    assert Model.model_validate({"value": "None"}).value is None
+
+
+def test_non_string_inputs_are_untouched() -> None:
+    """Non-string values are never substituted even if they would equal a sentinel."""
+
+    class Model(NullSentinels):
+        null_sentinels: ClassVar[frozenset[str]] = frozenset({""})
+
+        value: int | None
+
+    result = Model.model_validate({"value": 0})
+    assert result.value == 0
+
+
+def test_extra_fields_in_input_are_ignored() -> None:
+    """Keys in the input dict that aren't declared fields are not touched by the mixin."""
+
+    class Model(NullSentinels):
+        model_config = ConfigDict(extra="allow")
+        null_sentinels: ClassVar[frozenset[str]] = frozenset({""})
+
+        name: str
+
+    result = Model.model_validate({"name": "foo", "extra_field": ""})
+    assert result.model_extra == {"extra_field": ""}
+
+
+def test_subclass_can_opt_out() -> None:
+    """A subclass can override `null_sentinels` to an empty frozenset to disable substitution."""
+
+    class Parent(NullSentinels):
+        null_sentinels: ClassVar[frozenset[str]] = frozenset({""})
+
+        value: str | None
+
+    class Child(Parent):
+        null_sentinels: ClassVar[frozenset[str]] = frozenset()
+
+    assert Parent.model_validate({"value": ""}).value is None
+    assert Child.model_validate({"value": ""}).value == ""
+
+
+def test_sentinel_on_required_field_still_raises() -> None:
+    """A required field whose value matches a sentinel is not substituted, so pydantic raises."""
+
+    class Model(NullSentinels):
+        null_sentinels: ClassVar[frozenset[str]] = frozenset({""})
+
+        value: int
+
+    with pytest.raises(ValidationError):
+        Model.model_validate({"value": ""})


### PR DESCRIPTION
Closes #8.

## Summary

Extract the previous `_empty_field_to_none` validator from `Metric` into a new `NullSentinels` mixin (`fgmetric/mixins/_null_sentinels.py`) that exposes a configurable `null_sentinels: ClassVar[frozenset[str]]`. Users can now specify additional string sentinels (e.g., `"NA"`, `"None"`) to be treated as `None` on Optional fields.

`Metric` inherits the mixin and sets `null_sentinels = frozenset({""})` as its default, preserving the previous fgpyo-aligned "empty string means None" behavior.

## Design notes

A few design decisions that came out of planning:

**Scope: Optional fields only.** The substitution only applies to fields annotated as `T | None`. Non-Optional fields are untouched, which keeps the mixin composable with `DelimitedList`'s existing `list[T]` handling (where an empty cell is expected to reach `_split_lists` as `""` and become `[]`). An earlier pass tried an "any field" scope and broke the `list[int]` + empty-cell case.

**Narrower shape than originally proposed in #8.** Issue #8 suggested a `dict[str, Any]` class variable to support arbitrary mappings, motivated in part by a `{"NA": np.nan}` case. After planning we narrowed this to `frozenset[str]` since, once scoped to Optional fields, all mapped values are `None` — the set of null-sentinel strings is all we need. Multi-sentinel-to-null (e.g. `{"", "None"}`) is still supported.

**Subclasses opt out by overriding the ClassVar** to an empty `frozenset()`.

## Forward-looking: NaN-able float fields

The NaN use case from #8 (e.g. `"NA"` → `float('nan')` on non-Optional `float` fields) is deliberately **not** handled here. That concern is semantically distinct from null-on-Optional — it targets a disjoint set of fields (bare `float`, not `T | None`), and a naïve union under a broader `RemappedValues` mixin would collide with `DelimitedList`.

Intended follow-up: a focused mixin (provisional name `NaNableFloats` or similar) implemented as a `field_validator("*", mode="before")` that checks each field's annotation and swaps configured sentinels into `float('nan')` when the field is float-typed. Scoping this via a field validator keyed on annotation avoids any cross-cutting interaction with list parsing. I'll open a follow-up issue.

## Test plan

- [x] `uv run poe check-all` passes (format, lint, mypy, pytest: 83 passed)
- [x] Existing empty-field tests in `tests/test_metric.py` still pass without modification
- [x] New `tests/test_null_sentinels.py` covers: default no-op, `""` → `None`, non-Optional fields untouched, arbitrary sentinels on Optional fields, multi-sentinel, non-string inputs untouched, extra-field passthrough, subclass opt-out, required-field still raises `ValidationError`