### PR TITLE
feat: expose fieldnames arg in Metric.read

### DIFF
--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -128,9 +128,11 @@ class Metric(
         the model's field names when aliases are used.
 
         Note:
-            This method is deliberately not used during reading/validation. Note that the `read()`
-            method omits the `fieldnames` parameter from `csv.DictReader` so that any missing or
-            misspecified fields are handled by pydantic's model validation.
+            This method is deliberately not used during reading/validation.
+            By default, read() omits the fieldnames parameter from csv.DictReader so
+            missing/misspecified fields surface as Pydantic validation errors.
+            Callers may pass fieldnames explicitly when reading headerless files,
+            in which case responsibility for schema alignment shifts to the caller.
 
         Returns:
             The list of fieldnames to use as the header row.

--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from collections.abc import Sequence
 from csv import DictReader
+from itertools import chain
 from pathlib import Path
 from typing import Any
 from typing import Iterator
@@ -66,6 +67,16 @@ class Metric(
         """
         Read Metric instances from file.
 
+        When `fieldnames` is supplied, the file is assumed to be headerless and every row is
+        read as data. As a safeguard, if the first row exactly matches `fieldnames` it is
+        treated as a forgotten header and `ValueError` is raised — passing `fieldnames` is not
+        a way to override an existing header. To read a file that has a header, either strip
+        the header from the file, or omit `fieldnames` to let `csv.DictReader` consume it.
+
+        Raises:
+            ValueError: If `fieldnames` is supplied and the first row appears to be a header
+                that matches it.
+
         Example:
             Reading a file that has a header row:
 
@@ -86,7 +97,23 @@ class Metric(
         """
         # NOTE: the utf-8-sig encoding is required to auto-remove BOM from input file headers
         with path.open(encoding="utf-8-sig") as fin:
-            for record in DictReader(fin, fieldnames=fieldnames, delimiter=delimiter):
+            records: Iterator[dict[str, str | None]] = DictReader(
+                fin, fieldnames=fieldnames, delimiter=delimiter
+            )
+            if fieldnames is not None:
+                # NB: only a full match flags a header. A partial match is ambiguous —
+                # a single field value happening to equal its name is plausible data.
+                first = next(records, None)
+                if first is not None:
+                    # NB: short rows produce None for missing fields; .get() avoids KeyError.
+                    if all(first.get(f) == f for f in fieldnames):
+                        raise ValueError(
+                            "First row appears to be a header that matches `fieldnames`. "
+                            "Either drop `fieldnames` to read with the existing header, "
+                            "or strip the header from the file before reading."
+                        )
+                    records = chain([first], records)
+            for record in records:
                 yield cls.model_validate(record)
 
     # NB: "Before" validators (mode="before") run before field validators such as

--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from collections.abc import Sequence
 from csv import DictReader
 from pathlib import Path
 from typing import Any
@@ -56,19 +57,36 @@ class Metric(
     """
 
     @classmethod
-    def read(cls, path: Path, delimiter: str = "\t") -> Iterator[Self]:
+    def read(
+        cls,
+        path: Path,
+        delimiter: str = "\t",
+        fieldnames: Sequence[str] | None = None,
+    ) -> Iterator[Self]:
         """
         Read Metric instances from file.
 
         Example:
+            Reading a file that has a header row:
+
             ```python
             for m in AlignmentMetric.read(Path("out.tsv")):
+                print(m.read_name, m.mapping_quality)
+            ```
+
+            Reading a headerless file by supplying column names:
+
+            ```python
+            for m in AlignmentMetric.read(
+                Path("out.tsv"),
+                fieldnames=["read_name", "mapping_quality"],
+            ):
                 print(m.read_name, m.mapping_quality)
             ```
         """
         # NOTE: the utf-8-sig encoding is required to auto-remove BOM from input file headers
         with path.open(encoding="utf-8-sig") as fin:
-            for record in DictReader(fin, delimiter=delimiter):
+            for record in DictReader(fin, fieldnames=fieldnames, delimiter=delimiter):
                 yield cls.model_validate(record)
 
     # NB: "Before" validators (mode="before") run before field validators such as

--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -67,11 +67,18 @@ class Metric(
         """
         Read Metric instances from file.
 
+        By default, when `fieldnames` is omitted, the first row of the input file is read as
+        the header.
+
         When `fieldnames` is supplied, the file is assumed to be headerless and every row is
-        read as data. As a safeguard, if the first row exactly matches `fieldnames` it is
-        treated as a forgotten header and `ValueError` is raised — passing `fieldnames` is not
-        a way to override an existing header. To read a file that has a header, either strip
-        the header from the file, or omit `fieldnames` to let `csv.DictReader` consume it.
+        read as data. Rows shorter than `fieldnames` produce `None` for the missing fields,
+        which then go through normal model validation (raising `ValidationError` for required
+        fields).
+
+        As a safeguard, if the first row exactly matches `fieldnames` it is treated as a
+        forgotten header and `ValueError` is raised. Passing `fieldnames` is not a way to
+        override an existing header - to map differently-named header columns to model fields,
+        declare Pydantic field aliases on the `Metric` subclass.
 
         Raises:
             ValueError: If `fieldnames` is supplied and the first row appears to be a header
@@ -105,12 +112,10 @@ class Metric(
                 # a single field value happening to equal its name is plausible data.
                 first = next(records, None)
                 if first is not None:
-                    # NB: short rows produce None for missing fields; .get() avoids KeyError.
-                    if all(first.get(f) == f for f in fieldnames):
+                    if all(first[f] == f for f in fieldnames):
                         raise ValueError(
-                            "First row appears to be a header that matches `fieldnames`. "
-                            "Either drop `fieldnames` to read with the existing header, "
-                            "or strip the header from the file before reading."
+                            f"First row of {path} appears to be a header that matches "
+                            "`fieldnames`. Omit `fieldnames` to read with the existing header."
                         )
                     records = chain([first], records)
             for record in records:
@@ -155,11 +160,8 @@ class Metric(
         the model's field names when aliases are used.
 
         Note:
-            This method is deliberately not used during reading/validation.
-            By default, read() omits the fieldnames parameter from csv.DictReader so
-            missing/misspecified fields surface as Pydantic validation errors.
-            Callers may pass fieldnames explicitly when reading headerless files,
-            in which case responsibility for schema alignment shifts to the caller.
+            This method is deliberately not used during reading/validation; see `read()` for
+            the headerless-input path.
 
         Returns:
             The list of fieldnames to use as the header row.

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -335,7 +335,7 @@ def test_read_headerless_missing_required_field_raises(tmp_path: Path) -> None:
 
 
 def test_read_headerless_row_missing_column_raises(tmp_path: Path) -> None:
-    """When a row has fewer values than `fieldnames`, missing required fields raise."""
+    """When a row has fewer values than `fieldnames`, missing required fields raises."""
     fpath = tmp_path / "metrics.tsv"
     # Row only has "name", "count" is missing
     fpath.write_text("foo\n")
@@ -365,6 +365,50 @@ def test_read_headerless_row_extra_column_ignored(tmp_path: Path) -> None:
     assert len(metrics) == 1
     assert metrics[0].name == "foo"
     assert metrics[0].count == 1
+
+
+def test_read_headerless_detects_header_row_raises(tmp_path: Path) -> None:
+    """Passing `fieldnames` for a file that already has a matching header row raises."""
+    fpath = tmp_path / "metrics.tsv"
+    # File has a real header row that matches the supplied fieldnames
+    fpath.write_text("name\tcount\nfoo\t1\n")
+
+    with pytest.raises(ValueError, match="header"):
+        list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+
+
+def test_read_headerless_first_row_coincidentally_matching_value_is_data(
+    tmp_path: Path,
+) -> None:
+    """A single field whose value happens to match its fieldname is not flagged."""
+    fpath = tmp_path / "metrics.tsv"
+    fpath.write_text("name\t1\nbar\t2\n")
+
+    metrics = list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+
+    assert [m.name for m in metrics] == ["name", "bar"]
+    assert [m.count for m in metrics] == [1, 2]
+
+
+def test_read_headerless_detects_header_row_with_aliased_field_raises(tmp_path: Path) -> None:
+    """Header detection compares against supplied fieldnames, not model field names."""
+    fpath = tmp_path / "metrics.tsv"
+    # `MetricWithAlias` declares `read_count` aliased to "count"; the supplied fieldnames
+    # use the alias, and the file's header row matches those fieldnames.
+    fpath.write_text("name\tcount\nfoo\t1\n")
+
+    with pytest.raises(ValueError, match="header"):
+        list(MetricWithAlias.read(fpath, fieldnames=["name", "count"]))
+
+
+def test_read_headerless_empty_file(tmp_path: Path) -> None:
+    """An empty headerless file yields no metrics and does not raise."""
+    fpath = tmp_path / "metrics.tsv"
+    fpath.write_text("")
+
+    metrics = list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+
+    assert metrics == []
 
 
 # ======================================================================================

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -298,6 +298,76 @@ def test_read_extra_columns_ignored(tmp_path: Path) -> None:
 
 
 # ======================================================================================
+# Headerless file tests (explicit fieldnames)
+# ======================================================================================
+
+
+def test_read_headerless_with_fieldnames(tmp_path: Path) -> None:
+    """Reading a headerless TSV with `fieldnames` treats every row as data."""
+    fpath = tmp_path / "metrics.tsv"
+    # Three data rows, no header
+    fpath.write_text("foo\t1\nbar\t2\nbaz\t3\n")
+
+    metrics = list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+
+    assert [m.name for m in metrics] == ["foo", "bar", "baz"]
+    assert [m.count for m in metrics] == [1, 2, 3]
+
+
+def test_read_headerless_with_alias(tmp_path: Path) -> None:
+    """`fieldnames` may reference a field's alias, mirroring header-based reading."""
+    fpath = tmp_path / "metrics.tsv"
+    fpath.write_text("foo\t100\n")
+
+    metrics = list(MetricWithAlias.read(fpath, fieldnames=["name", "count"]))
+
+    assert metrics[0].name == "foo"
+    assert metrics[0].read_count == 100
+
+
+def test_read_headerless_missing_required_field_raises(tmp_path: Path) -> None:
+    """A headerless file missing a required field still raises ValidationError."""
+    fpath = tmp_path / "metrics.tsv"
+    fpath.write_text("foo\n")
+
+    with pytest.raises(ValidationError):
+        list(SimpleMetric.read(fpath, fieldnames=["name"]))
+
+
+def test_read_headerless_row_missing_column_raises(tmp_path: Path) -> None:
+    """When a row has fewer values than `fieldnames`, missing required fields raise."""
+    fpath = tmp_path / "metrics.tsv"
+    # Row only has "name", "count" is missing
+    fpath.write_text("foo\n")
+
+    with pytest.raises(ValidationError):
+        list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+
+
+def test_read_headerless_short_row_among_valid_rows_raises(tmp_path: Path) -> None:
+    """A single short row among otherwise-valid rows still raises ValidationError."""
+    fpath = tmp_path / "metrics.tsv"
+    # The middle row is missing the "count" value
+    fpath.write_text("foo\t1\nbar\nbaz\t3\n")
+
+    with pytest.raises(ValidationError):
+        list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+
+
+def test_read_headerless_row_extra_column_ignored(tmp_path: Path) -> None:
+    """When a row has more values than `fieldnames`, the extras are ignored."""
+    fpath = tmp_path / "metrics.tsv"
+    # Row has an extra value not covered by fieldnames
+    fpath.write_text("foo\t1\textra\n")
+
+    metrics = list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+
+    assert len(metrics) == 1
+    assert metrics[0].name == "foo"
+    assert metrics[0].count == 1
+
+
+# ======================================================================================
 # Parent/subclass tests
 # ======================================================================================
 


### PR DESCRIPTION
Closes #37 

Minimal code change.

I'm interested in if we want to adjust any of the default behavior with how this interacts with `model_validate()`. 

I believe I got test cases added for the most interesting interactions (different versions of missing data), but open to adding more coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional field-name support for reading headerless delimited files with an example in docs; detects and rejects when the first row matches the supplied field names (raises an error).

* **Tests**
  * Added comprehensive tests for headerless reading, alias mapping, header-detection, missing/short required fields raising validation errors, ignoring extra columns, and empty-file behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/fgmetric/pull/38)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->