### PR TITLE
chore: Bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-05-12
+
+### 🚀 Features
+
+- Expose `fieldnames` arg in `Metric.read` (#38)
+
+### 🐛 Bug Fixes
+
+- Update repository URLs to fg-labs after org transfer (#32)
+
+### 📚 Documentation
+
+- Add Fulcrum Genomics branding to README (#33)
+
 ## [0.2.0] - 2026-03-13
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name            = "fgmetric"
-version         = "0.2.0"
+version         = "0.3.0"
 description     = "Pydantic-backed Metric."
 readme          = "README.md"
 authors         = [{ name="Fulcrum Genomics LLC", email="contact@fulcrumgenomics.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "fgmetric"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
Bump version from 0.2.0 to 0.3.0 and update CHANGELOG.

Highlights since 0.2.0:
- `Metric.read` now accepts an explicit `fieldnames` argument (#38)

## Test plan
- [ ] CI checks pass
- [ ] After merge, tag `0.3.0` and push to trigger publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `fieldnames` argument to `Metric.read`.

* **Bug Fixes**
  * Updated repository URLs.

* **Documentation**
  * Added Fulcrum Genomics branding to README.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/fgmetric/pull/39)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->