### PR TITLE
feat: introduce MetricReader for IO-based metric reading

### DIFF
--- a/fgmetric/__init__.py
+++ b/fgmetric/__init__.py
@@ -1,7 +1,9 @@
 from fgmetric.metric import Metric
+from fgmetric.metric_reader import MetricReader
 from fgmetric.metric_writer import MetricWriter
 
 __all__ = [
     "Metric",
+    "MetricReader",
     "MetricWriter",
 ]

--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -1,7 +1,5 @@
 from abc import ABC
 from collections.abc import Sequence
-from csv import DictReader
-from itertools import chain
 from pathlib import Path
 from typing import Any
 from typing import Iterator
@@ -13,6 +11,7 @@ from pydantic import model_validator
 from fgmetric._typing_extensions import is_optional
 from fgmetric.collections import CounterPivotTable
 from fgmetric.collections import DelimitedList
+from fgmetric.metric_reader import MetricReader
 
 
 class Metric(
@@ -65,7 +64,9 @@ class Metric(
         fieldnames: Sequence[str] | None = None,
     ) -> Iterator[Self]:
         """
-        Read Metric instances from file.
+        Read Metric instances from a file path.
+
+        Thin wrapper around `MetricReader.open()`.
 
         By default, when `fieldnames` is omitted, the first row of the input file is read as
         the header.
@@ -79,6 +80,16 @@ class Metric(
         forgotten header and `ValueError` is raised. Passing `fieldnames` is not a way to
         override an existing header - to map differently-named header columns to model fields,
         declare Pydantic field aliases on the `Metric` subclass.
+
+        Args:
+            path: Filesystem path to the input file.
+            delimiter: The input file delimiter.
+            fieldnames: Optional sequence of field names. If provided, the input
+                is treated as headerless and these names are used as the column
+                headers.
+
+        Yields:
+            Instances of the calling Metric subclass, one per data row.
 
         Raises:
             ValueError: If `fieldnames` is supplied and the first row appears to be a header
@@ -102,24 +113,8 @@ class Metric(
                 print(m.read_name, m.mapping_quality)
             ```
         """
-        # NOTE: the utf-8-sig encoding is required to auto-remove BOM from input file headers
-        with path.open(encoding="utf-8-sig") as fin:
-            records: Iterator[dict[str, str | None]] = DictReader(
-                fin, fieldnames=fieldnames, delimiter=delimiter
-            )
-            if fieldnames is not None:
-                # NB: only a full match flags a header. A partial match is ambiguous —
-                # a single field value happening to equal its name is plausible data.
-                first = next(records, None)
-                if first is not None:
-                    if all(first[f] == f for f in fieldnames):
-                        raise ValueError(
-                            f"First row of {path} appears to be a header that matches "
-                            "`fieldnames`. Omit `fieldnames` to read with the existing header."
-                        )
-                    records = chain([first], records)
-            for record in records:
-                yield cls.model_validate(record)
+        with MetricReader.open(cls, path, delimiter, fieldnames) as reader:
+            yield from reader
 
     # NB: "Before" validators (mode="before") run before field validators such as
     # `DelimitedList._split_lists()`. Empty strings in Optional fields will always be converted to

--- a/fgmetric/metric_reader.py
+++ b/fgmetric/metric_reader.py
@@ -1,0 +1,100 @@
+from collections.abc import Iterable
+from collections.abc import Iterator
+from collections.abc import Sequence
+from contextlib import contextmanager
+from csv import DictReader
+from itertools import chain
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Self
+
+if TYPE_CHECKING:
+    from fgmetric.metric import Metric
+
+
+class MetricReader[T: Metric]:
+    """
+    Iterate `Metric` instances from a text IO source.
+
+    Constructed with any iterable of strings (file handle, StringIO, list of
+    lines). The reader does not own the source; callers manage its lifecycle.
+    Use the `open` classmethod to open and read a file in one step.
+    """
+
+    _metric_class: type[T]
+    _records: Iterator[dict[str, str | None]]
+
+    def __init__(
+        self,
+        metric_class: type[T],
+        source: Iterable[str],
+        delimiter: str = "\t",
+        fieldnames: Sequence[str] | None = None,
+    ) -> None:
+        """
+        Initialize a new `MetricReader`.
+
+        Args:
+            metric_class: Metric class.
+            source: An iterable of strings (e.g., file handle, StringIO) to read from.
+            delimiter: The input file delimiter.
+            fieldnames: Optional sequence of field names. If provided, the input is treated as
+                headerless and these names are used as the column headers.
+
+        Raises:
+            ValueError: If `fieldnames` is supplied and the first row appears to be a header
+                that matches it.
+        """
+        self._metric_class = metric_class
+        records: Iterator[dict[str, str | None]] = DictReader(
+            source,
+            fieldnames=fieldnames,
+            delimiter=delimiter,
+        )
+        if fieldnames is not None:
+            first = next(records, None)
+            if first is not None:
+                # NB: only a full match flags a header. A partial match is ambiguous —
+                # a single field value happening to equal its name is plausible data.
+                if all(first[f] == f for f in fieldnames):
+                    raise ValueError(
+                        "First row appears to be a header that matches `fieldnames`. "
+                        "Omit `fieldnames` to read with the existing header."
+                    )
+                records = chain([first], records)
+        self._records = records
+
+    @classmethod
+    @contextmanager
+    def open(
+        cls,
+        metric_class: type[T],
+        path: Path | str,
+        delimiter: str = "\t",
+        fieldnames: Sequence[str] | None = None,
+    ) -> Iterator[Self]:
+        """
+        Open `path` and yield a `MetricReader` over its contents.
+
+        The file is opened with `encoding="utf-8-sig"` (strips a UTF-8 BOM if
+        present) and closed on context exit. Compression is not yet supported.
+
+        Args:
+            metric_class: Metric class.
+            path: Filesystem path to the input file.
+            delimiter: The input file delimiter.
+            fieldnames: Optional sequence of field names. If provided, the input is
+                treated as headerless and these names are used as the column
+                headers.
+
+        Yields:
+            A `MetricReader` over the opened file.
+        """
+        with Path(path).open(encoding="utf-8-sig") as handle:
+            yield cls(metric_class, handle, delimiter, fieldnames)
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> T:
+        return self._metric_class.model_validate(next(self._records))

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import assert_type
 
 import pytest
 from pydantic import Field
@@ -98,6 +99,7 @@ def test_read_yields_correct_type(tmp_path: Path) -> None:
     fpath.write_text("name\tcount\nfoo\t1\n")
 
     for metric in SimpleMetric.read(fpath):
+        assert_type(metric, SimpleMetric)
         assert isinstance(metric, SimpleMetric)
 
 

--- a/tests/test_metric_reader.py
+++ b/tests/test_metric_reader.py
@@ -1,0 +1,79 @@
+from io import StringIO
+from pathlib import Path
+from typing import assert_type
+
+import pytest
+
+from fgmetric.metric import Metric
+from fgmetric.metric_reader import MetricReader
+
+
+class ExampleMetric(Metric):
+    """Example Metric subclass used in MetricReader tests."""
+
+    name: str
+    value: int
+
+
+def test_reader_iterates_from_iterable() -> None:
+    source = StringIO("name\tvalue\nalice\t1\nbob\t2\n")
+    reader = MetricReader(ExampleMetric, source)
+    assert_type(reader, MetricReader[ExampleMetric])
+    metrics = list(reader)
+    assert_type(metrics, list[ExampleMetric])
+    assert metrics == [
+        ExampleMetric(name="alice", value=1),
+        ExampleMetric(name="bob", value=2),
+    ]
+
+
+def test_reader_supports_headerless_with_fieldnames() -> None:
+    source = StringIO("alice\t1\nbob\t2\n")
+    reader = MetricReader(ExampleMetric, source, fieldnames=["name", "value"])
+    metrics = list(reader)
+    assert metrics == [
+        ExampleMetric(name="alice", value=1),
+        ExampleMetric(name="bob", value=2),
+    ]
+
+
+def test_reader_rejects_fieldnames_matching_header_at_construction() -> None:
+    source = StringIO("name\tvalue\nalice\t1\n")
+    with pytest.raises(ValueError, match="appears to be a header"):
+        MetricReader(ExampleMetric, source, fieldnames=["name", "value"])
+
+
+def test_reader_does_not_close_caller_handle() -> None:
+    source = StringIO("name\tvalue\nalice\t1\n")
+    reader = MetricReader(ExampleMetric, source)
+    list(reader)
+    assert not source.closed
+
+
+def test_open_reads_file(tmp_path: Path) -> None:
+    p = tmp_path / "metrics.tsv"
+    p.write_text("name\tvalue\nalice\t1\nbob\t2\n")
+    with MetricReader.open(ExampleMetric, p) as reader:
+        assert_type(reader, MetricReader[ExampleMetric])
+        metrics = list(reader)
+    assert_type(metrics, list[ExampleMetric])
+    assert metrics == [
+        ExampleMetric(name="alice", value=1),
+        ExampleMetric(name="bob", value=2),
+    ]
+
+
+def test_open_does_not_open_file_until_enter(tmp_path: Path) -> None:
+    p = tmp_path / "missing.tsv"
+    cm = MetricReader.open(ExampleMetric, p)
+    with pytest.raises(FileNotFoundError):
+        with cm:
+            pass
+
+
+def test_open_requires_context_manager_usage(tmp_path: Path) -> None:
+    p = tmp_path / "metrics.tsv"
+    p.write_text("name\tvalue\nalice\t1\n")
+    cm = MetricReader.open(ExampleMetric, p)
+    with pytest.raises(TypeError):
+        list(cm)  # type: ignore[call-overload]


### PR DESCRIPTION
## Summary

First of four PRs to refactor to provide better support for arbitrary file handle inputs and add support for gzipped input. 

This PR adds a new class `MetricReader`, whose API mirrors the existing `MetricWriter`. `MetricReader` is initialized with an open file handle (or any `Iterable[str]`) and provides the `open()` class method to read directly from filepath.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MetricReader utility class now available for reading metric instances from files and iterables with support for headerless data and custom delimiters.

* **Refactor**
  * Metric file parsing has been refactored for improved consistency and maintainability.

* **Tests**
  * Added comprehensive test coverage for MetricReader functionality including file operations and headerless input handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/fgmetric/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->