### PR TITLE
refactor: IO-first MetricWriter with open() classmethod

### DIFF
--- a/fgmetric/metric_writer.py
+++ b/fgmetric/metric_writer.py
@@ -1,122 +1,94 @@
-from contextlib import AbstractContextManager
+from collections.abc import Iterable
+from collections.abc import Iterator
+from contextlib import contextmanager
 from csv import DictWriter
-from io import TextIOWrapper
 from pathlib import Path
-from types import TracebackType
-from typing import Iterable
 from typing import Self
+from typing import TextIO
 
 from fgmetric.metric import Metric
 
 
-class MetricWriter[T: Metric](AbstractContextManager):
+class MetricWriter[T: Metric]:
     """
-    Context manager for writing Metric instances to delimited text files.
+    Write `Metric` instances to a text IO sink.
 
-    This class provides a convenient interface for serializing Metric objects to TSV, CSV, or other
-    delimited file formats. It automatically writes column headers based on the Metric class fields
-    and handles the conversion from Pydantic models to dictionary rows. The writer implements the
-    context manager protocol for safe file handling and supports both single and batch writing
-    operations. Field aliases are respected when writing headers and data.
-
-    Example:
-        ```python
-        class AlignmentMetric(Metric):
-            read_name: str
-            mapping_quality: int
-            is_duplicate: bool = False
-
-        metrics = [
-            AlignmentMetric(read_name="read1", mapping_quality=60, is_duplicate=False),
-            AlignmentMetric(read_name="read2", mapping_quality=30, is_duplicate=True),
-        ]
-
-        with MetricWriter(AlignmentMetric, Path("output.tsv")) as writer:
-            writer.writeall(metrics)
-        ```
-
-    Note:
-        The file is opened immediately upon initialization and the header row is written
-        automatically. Use the context manager interface to ensure proper file closure.
+    Construction takes a writable text IO and writes the header row immediately.
+    The writer does not own the sink; callers manage its lifecycle. Use the
+    `open` classmethod to open and write to a file in one step.
     """
 
     _metric_class: type[T]
-    _fout: TextIOWrapper
     _writer: DictWriter[str]
 
     def __init__(
         self,
         metric_class: type[T],
-        filename: Path | str,
+        sink: TextIO,
         delimiter: str = "\t",
         lineterminator: str = "\n",
     ) -> None:
         """
-        Initialize a new `MetricWriter`.
+        Initialize a new `MetricWriter` and write the header row to `sink`.
 
         Args:
-            filename: Path to the file to write.
             metric_class: Metric class.
+            sink: Writable text IO (e.g., file handle, StringIO) to write to.
             delimiter: The output file delimiter.
-            lineterminator: The string used to terminate lines produced by the MetricWriter.
+            lineterminator: The string used to terminate lines.
         """
         self._metric_class = metric_class
-        self._fout = Path(filename).open("w", encoding="utf-8")
+        self._writer = DictWriter(
+            f=sink,
+            fieldnames=metric_class._header_fieldnames(),
+            delimiter=delimiter,
+            lineterminator=lineterminator,
+        )
+        self._writer.writeheader()
 
-        try:
-            self._writer = DictWriter(
-                f=self._fout,
-                fieldnames=self._metric_class._header_fieldnames(),
-                delimiter=delimiter,
-                lineterminator=lineterminator,
-            )
+    @classmethod
+    @contextmanager
+    def open(
+        cls,
+        metric_class: type[T],
+        path: Path | str,
+        delimiter: str = "\t",
+        lineterminator: str = "\n",
+    ) -> Iterator[Self]:
+        """
+        Open `path` for writing and yield a `MetricWriter` over it.
 
-            self._writer.writeheader()
-        except Exception:
-            self._fout.close()
-            raise
+        The file is opened with `encoding="utf-8"`. The header is written on
+        context entry; the file is closed on context exit. Compression is not
+        yet supported.
 
-    def __enter__(self) -> Self:
-        return self
+        Args:
+            metric_class: Metric class.
+            path: Filesystem path to the output file.
+            delimiter: The output file delimiter.
+            lineterminator: The string used to terminate lines.
 
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None = None,
-        exc_value: BaseException | None = None,
-        traceback: TracebackType | None = None,
-    ) -> None:
-        self.close()
-        super().__exit__(exc_type, exc_value, traceback)
-
-    def close(self) -> None:
-        """Close the underlying file handle."""
-        self._fout.close()
+        Yields:
+            A `MetricWriter` over the opened file.
+        """
+        with Path(path).open("w", encoding="utf-8") as handle:
+            yield cls(metric_class, handle, delimiter, lineterminator)
 
     def write(self, metric: T) -> None:
         """
-        Write a single Metric instance to file.
-
-        The Metric is serialized using ``model_dump(mode="json")`` and then written using the
-        underlying `DictWriter`. JSON mode ensures that all field values (e.g., enums) are
-        converted to JSON-compatible types before writing.
+        Write a single `Metric` instance.
 
         Args:
-            metric: An instance of the specified Metric.
-
-        Raises:
-            TypeError: If the provided `metric` is not an instance of the Metric class used to
-                parametrize the writer.
+            metric: An instance of the writer's metric class.
         """
         self._writer.writerow(metric.model_dump(mode="json"))
 
     def writeall(self, metrics: Iterable[T]) -> None:
         """
-        Write multiple Metric instances to file.
-
-        Each Metric is converted to a dictionary and then written using the underlying `DictWriter`.
+        Write multiple `Metric` instances.
 
         Args:
-            metrics: A sequence of instances of the specified Metric.
+            metrics: An iterable of instances of the writer's metric class.
         """
         for metric in metrics:
             self.write(metric)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -39,7 +39,7 @@ def test_comma_delimited_list(tmp_path: Path) -> None:
     # Test writing
     fpath_to_write = tmp_path / "written.txt"
     writer: MetricWriter[FakeMetric]
-    with MetricWriter(FakeMetric, fpath_to_write) as writer:
+    with MetricWriter.open(FakeMetric, fpath_to_write) as writer:
         writer.writeall(metrics)
 
     with fpath_to_write.open("r") as f:
@@ -74,7 +74,7 @@ def test_other_delimited_list(tmp_path: Path) -> None:
     # Test writing
     fpath_to_write = tmp_path / "written.txt"
     writer: MetricWriter[FakeMetric]
-    with MetricWriter(FakeMetric, fpath_to_write) as writer:
+    with MetricWriter.open(FakeMetric, fpath_to_write) as writer:
         writer.write(metrics[0])
 
     with fpath_to_write.open("r") as f:
@@ -94,7 +94,7 @@ def test_delimited_list_with_complex_types(tmp_path: Path) -> None:
     # Test writing
     fpath_to_write = tmp_path / "written.txt"
     writer: MetricWriter[FakeMetric]
-    with MetricWriter(FakeMetric, fpath_to_write) as writer:
+    with MetricWriter.open(FakeMetric, fpath_to_write) as writer:
         writer.write(FakeMetric(name="Clint", values=[0.1, 0.002, 0.00301]))
 
     with fpath_to_write.open("r") as f:
@@ -132,7 +132,7 @@ def test_delimited_list_with_optional_field(tmp_path: Path) -> None:
     # Test writing
     fpath_to_write = tmp_path / "written.txt"
     writer: MetricWriter[FakeMetric]
-    with MetricWriter(FakeMetric, fpath_to_write) as writer:
+    with MetricWriter.open(FakeMetric, fpath_to_write) as writer:
         writer.writeall(metrics)
 
     with fpath_to_write.open("r") as f:
@@ -194,7 +194,7 @@ def test_counter_pivot_table_of_enum(tmp_path: Path) -> None:
     fpath_to_write = tmp_path / "written.txt"
 
     writer: MetricWriter[FakeMetric]
-    with MetricWriter(FakeMetric, fpath_to_write) as writer:
+    with MetricWriter.open(FakeMetric, fpath_to_write) as writer:
         writer.write(FakeMetric(name="Tim", counts=Counter({FakeEnum.FOO: 3, FakeEnum.BAR: 4})))
 
     with fpath_to_write.open("r") as f:

--- a/tests/test_metric_writer.py
+++ b/tests/test_metric_writer.py
@@ -1,9 +1,9 @@
 from collections import Counter
 from enum import StrEnum
 from enum import unique
+from io import StringIO
 from pathlib import Path
 from typing import assert_type
-from unittest import mock
 
 import pytest
 
@@ -23,7 +23,7 @@ def test_writer(tmp_path: Path) -> None:
     fpath = tmp_path / "test.txt"
 
     writer: MetricWriter[FakeMetric]
-    with MetricWriter(FakeMetric, fpath) as writer:
+    with MetricWriter.open(FakeMetric, fpath) as writer:
         assert_type(writer, MetricWriter[FakeMetric])
         writer.write(FakeMetric(foo="abc", bar=1))
         writer.write(FakeMetric(foo="def", bar=2))
@@ -34,22 +34,6 @@ def test_writer(tmp_path: Path) -> None:
         assert next(f) == "def\t2\n"
         with pytest.raises(StopIteration):
             next(f)
-
-
-def test_init_closes_file_on_failure(tmp_path: Path) -> None:
-    """Test that the file handle is closed if __init__ raises after opening."""
-    fpath = tmp_path / "test.txt"
-    fpath.touch()
-    real_fout = fpath.open("w")
-
-    with (
-        mock.patch("fgmetric.metric_writer.Path.open", return_value=real_fout),
-        mock.patch.object(FakeMetric, "_header_fieldnames", side_effect=ValueError("boom")),
-        pytest.raises(ValueError, match="boom"),
-    ):
-        MetricWriter(FakeMetric, fpath)
-
-    assert real_fout.closed
 
 
 def test_writer_with_counter_metric(tmp_path: Path) -> None:
@@ -66,7 +50,7 @@ def test_writer_with_counter_metric(tmp_path: Path) -> None:
 
     fpath = tmp_path / "test.txt"
 
-    with MetricWriter(CounterMetric, fpath) as writer:
+    with MetricWriter.open(CounterMetric, fpath) as writer:
         writer.write(CounterMetric(name="test", counts=Counter({FakeEnum.FOO: 3, FakeEnum.BAR: 4})))
 
     with fpath.open("r") as f:
@@ -74,3 +58,43 @@ def test_writer_with_counter_metric(tmp_path: Path) -> None:
         assert next(f) == "test\t3\t4\n"
         with pytest.raises(StopIteration):
             next(f)
+
+
+def test_writer_accepts_text_io_and_writes_to_it() -> None:
+    """A writer constructed with a TextIO sink writes to that sink."""
+    sink = StringIO()
+    writer = MetricWriter(FakeMetric, sink)
+    writer.write(FakeMetric(foo="abc", bar=1))
+    assert sink.getvalue() == "foo\tbar\nabc\t1\n"
+
+
+def test_writer_writes_header_at_construction() -> None:
+    """The header row is written immediately on construction."""
+    sink = StringIO()
+    MetricWriter(FakeMetric, sink)
+    assert sink.getvalue() == "foo\tbar\n"
+
+
+def test_writer_does_not_close_caller_handle() -> None:
+    """A caller-supplied sink is not closed by the writer."""
+    sink = StringIO()
+    writer = MetricWriter(FakeMetric, sink)
+    writer.write(FakeMetric(foo="abc", bar=1))
+    assert not sink.closed
+
+
+def test_writer_open_writes_header_and_rows(tmp_path: Path) -> None:
+    """Test that MetricWriter.open opens a file, writes the header, and writes rows."""
+    p = tmp_path / "out.tsv"
+    with MetricWriter.open(FakeMetric, p) as writer:
+        writer.write(FakeMetric(foo="abc", bar=1))
+    assert p.read_text() == "foo\tbar\nabc\t1\n"
+
+
+def test_writer_open_does_not_touch_file_until_enter(tmp_path: Path) -> None:
+    """Test that MetricWriter.open does not open the file until the context is entered."""
+    p = tmp_path / "out.tsv"
+    p.write_text("existing content\n")
+    MetricWriter.open(FakeMetric, p)
+    # Construction alone must not truncate or rewrite the file.
+    assert p.read_text() == "existing content\n"


### PR DESCRIPTION
## Summary

Second of four PRs to refactor to provide better support for arbitrary file handle inputs and add support for gzipped input.

This PR refactors `MetricWriter` to mirror the API introduced in #41 for `MetricReader`. `MetricWriter` is now instantiated over any open file handle, with a `open()` classmethod to open directly from filepath.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Metric writer API changed: use the new context-managed open(...) pattern instead of direct construction; writers now accept an already-open output sink and write headers immediately.
* **Tests**
  * Updated tests to use the new open(...) usage and added coverage for sink lifecycle, immediate header writing, in-memory sinks, and context-managed file writes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/fgmetric/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->