### PR TITLE
feat: encoding kwarg on path-opening classmethods

### DIFF
--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -62,6 +62,7 @@ class Metric(
         path: Path,
         delimiter: str = "\t",
         fieldnames: Sequence[str] | None = None,
+        encoding: str = "utf-8-sig",
     ) -> Iterator[Self]:
         """
         Read Metric instances from a file path.
@@ -87,6 +88,7 @@ class Metric(
             fieldnames: Optional sequence of field names. If provided, the input
                 is treated as headerless and these names are used as the column
                 headers.
+            encoding: The text encoding used to decode the file.
 
         Yields:
             Instances of the calling Metric subclass, one per data row.
@@ -113,7 +115,13 @@ class Metric(
                 print(m.read_name, m.mapping_quality)
             ```
         """
-        with MetricReader.open(cls, path, delimiter, fieldnames) as reader:
+        with MetricReader.open(
+            cls,
+            path,
+            delimiter=delimiter,
+            fieldnames=fieldnames,
+            encoding=encoding,
+        ) as reader:
             yield from reader
 
     # NB: "Before" validators (mode="before") run before field validators such as

--- a/fgmetric/metric_reader.py
+++ b/fgmetric/metric_reader.py
@@ -77,7 +77,7 @@ class MetricReader[T: Metric]:
         """
         Open `path` and yield a `MetricReader` over its contents.
 
-        The file is opened with the given encoding and closed on context exit. The default encoding
+        The file is opened with the given encoding and closed on context exit. The default encoding,
         `utf-8-sig`, will cleanly open Excel-generated CSVs by removing any UTF-8 BOM (if present).
         Compression is not yet supported.
 

--- a/fgmetric/metric_reader.py
+++ b/fgmetric/metric_reader.py
@@ -72,12 +72,14 @@ class MetricReader[T: Metric]:
         path: Path | str,
         delimiter: str = "\t",
         fieldnames: Sequence[str] | None = None,
+        encoding: str = "utf-8-sig",
     ) -> Iterator[Self]:
         """
         Open `path` and yield a `MetricReader` over its contents.
 
-        The file is opened with `encoding="utf-8-sig"` (strips a UTF-8 BOM if
-        present) and closed on context exit. Compression is not yet supported.
+        The file is opened with the given encoding and closed on context exit. The default encoding
+        `utf-8-sig`, will cleanly open Excel-generated CSVs by removing any UTF-8 BOM (if present).
+        Compression is not yet supported.
 
         Args:
             metric_class: Metric class.
@@ -86,11 +88,12 @@ class MetricReader[T: Metric]:
             fieldnames: Optional sequence of field names. If provided, the input is
                 treated as headerless and these names are used as the column
                 headers.
+            encoding: The text encoding used to decode the file.
 
         Yields:
             A `MetricReader` over the opened file.
         """
-        with Path(path).open(encoding="utf-8-sig") as handle:
+        with Path(path).open(encoding=encoding) as handle:
             yield cls(metric_class, handle, delimiter, fieldnames)
 
     def __iter__(self) -> Self:

--- a/fgmetric/metric_writer.py
+++ b/fgmetric/metric_writer.py
@@ -54,24 +54,26 @@ class MetricWriter[T: Metric]:
         path: Path | str,
         delimiter: str = "\t",
         lineterminator: str = "\n",
+        encoding: str = "utf-8",
     ) -> Iterator[Self]:
         """
         Open `path` for writing and yield a `MetricWriter` over it.
 
-        The file is opened with `encoding="utf-8"`. The header is written on
-        context entry; the file is closed on context exit. Compression is not
-        yet supported.
+        The file is opened with the given encoding (default `utf-8`). The header
+        is written on context entry; the file is closed on context exit.
+        Compression is not yet supported.
 
         Args:
             metric_class: Metric class.
             path: Filesystem path to the output file.
             delimiter: The output file delimiter.
             lineterminator: The string used to terminate lines.
+            encoding: The text encoding used to write the file.
 
         Yields:
             A `MetricWriter` over the opened file.
         """
-        with Path(path).open("w", encoding="utf-8") as handle:
+        with Path(path).open("w", encoding=encoding) as handle:
             yield cls(metric_class, handle, delimiter, lineterminator)
 
     def write(self, metric: T) -> None:

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -436,3 +436,11 @@ def test_read_parent_class_discards_subclass_fields(tmp_path: Path) -> None:
     assert metrics[0].value == 42
     assert not hasattr(metrics[0], "extra_field")
     assert not hasattr(metrics[0], "another_field")
+
+
+def test_read_respects_encoding(tmp_path: Path) -> None:
+    """Test that Metric.read forwards the encoding kwarg to MetricReader.open."""
+    fpath = tmp_path / "metrics.tsv"
+    fpath.write_bytes("name\tcount\nrené\t1\n".encode("latin-1"))
+    metrics = list(SimpleMetric.read(fpath, encoding="latin-1"))
+    assert metrics == [SimpleMetric(name="rené", count=1)]

--- a/tests/test_metric_reader.py
+++ b/tests/test_metric_reader.py
@@ -77,3 +77,12 @@ def test_open_requires_context_manager_usage(tmp_path: Path) -> None:
     cm = MetricReader.open(ExampleMetric, p)
     with pytest.raises(TypeError):
         list(cm)  # type: ignore[call-overload]
+
+
+def test_open_respects_encoding(tmp_path: Path) -> None:
+    """Test that MetricReader.open decodes the file with the specified encoding."""
+    p = tmp_path / "metrics.tsv"
+    p.write_bytes("name\tvalue\nrené\t1\n".encode("latin-1"))
+    with MetricReader.open(ExampleMetric, p, encoding="latin-1") as reader:
+        metrics = list(reader)
+    assert metrics == [ExampleMetric(name="rené", value=1)]

--- a/tests/test_metric_writer.py
+++ b/tests/test_metric_writer.py
@@ -98,3 +98,11 @@ def test_writer_open_does_not_touch_file_until_enter(tmp_path: Path) -> None:
     MetricWriter.open(FakeMetric, p)
     # Construction alone must not truncate or rewrite the file.
     assert p.read_text() == "existing content\n"
+
+
+def test_writer_open_respects_encoding(tmp_path: Path) -> None:
+    """Test that MetricWriter.open writes with the specified encoding."""
+    p = tmp_path / "out.tsv"
+    with MetricWriter.open(FakeMetric, p, encoding="latin-1") as writer:
+        writer.write(FakeMetric(foo="rené", bar=1))
+    assert p.read_bytes() == "foo\tbar\nrené\t1\n".encode("latin-1")


### PR DESCRIPTION
## Summary

Third of four PRs to refactor to provide better support for arbitrary file handle inputs and add support for gzipped input.

This PR exposes the `encoding` used by the underlying `DictReader`/`DictWriter` as a parameter on the corresponding `MetricReader`/`MetricWriter`. Rationale for the choice of `utf-8-sig` as default is documented.

Note: it would be a worthwhile follow-up to expose the other arguments that `DictReader` and `DictWriter` take.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Metric file operations now support configurable text encoding, allowing users to specify custom character encodings for reading and writing instead of using hardcoded defaults.

* **Tests**
  * Added tests verifying custom encoding parameters work correctly during file I/O operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/fgmetric/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->