### PR TITLE
feat!: remove Metric.read in favor of MetricReader.open

### DIFF
--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -1,9 +1,5 @@
 from abc import ABC
-from collections.abc import Sequence
-from pathlib import Path
 from typing import Any
-from typing import Iterator
-from typing import Self
 
 from pydantic import BaseModel
 from pydantic import model_validator
@@ -11,7 +7,6 @@ from pydantic import model_validator
 from fgmetric._typing_extensions import is_optional
 from fgmetric.collections import CounterPivotTable
 from fgmetric.collections import DelimitedList
-from fgmetric.metric_reader import MetricReader
 
 
 class Metric(
@@ -45,84 +40,19 @@ class Metric(
 
     Example:
         ```python
+        from fgmetric import MetricReader
+
         class AlignmentMetric(Metric):
             read_name: str
             mapping_quality: int
             is_duplicate: bool = False
 
         # Read metrics from a TSV file
-        for metric in AlignmentMetric.read(Path("metrics.txt")):
-            print(metric.read_name, metric.mapping_quality)
+        with MetricReader.open(AlignmentMetric, "metrics.txt") as reader:
+            for metric in reader:
+                print(metric.read_name, metric.mapping_quality)
         ```
     """
-
-    @classmethod
-    def read(
-        cls,
-        path: Path,
-        delimiter: str = "\t",
-        fieldnames: Sequence[str] | None = None,
-        encoding: str = "utf-8-sig",
-    ) -> Iterator[Self]:
-        """
-        Read Metric instances from a file path.
-
-        Thin wrapper around `MetricReader.open()`.
-
-        By default, when `fieldnames` is omitted, the first row of the input file is read as
-        the header.
-
-        When `fieldnames` is supplied, the file is assumed to be headerless and every row is
-        read as data. Rows shorter than `fieldnames` produce `None` for the missing fields,
-        which then go through normal model validation (raising `ValidationError` for required
-        fields).
-
-        As a safeguard, if the first row exactly matches `fieldnames` it is treated as a
-        forgotten header and `ValueError` is raised. Passing `fieldnames` is not a way to
-        override an existing header - to map differently-named header columns to model fields,
-        declare Pydantic field aliases on the `Metric` subclass.
-
-        Args:
-            path: Filesystem path to the input file.
-            delimiter: The input file delimiter.
-            fieldnames: Optional sequence of field names. If provided, the input
-                is treated as headerless and these names are used as the column
-                headers.
-            encoding: The text encoding used to decode the file.
-
-        Yields:
-            Instances of the calling Metric subclass, one per data row.
-
-        Raises:
-            ValueError: If `fieldnames` is supplied and the first row appears to be a header
-                that matches it.
-
-        Example:
-            Reading a file that has a header row:
-
-            ```python
-            for m in AlignmentMetric.read(Path("out.tsv")):
-                print(m.read_name, m.mapping_quality)
-            ```
-
-            Reading a headerless file by supplying column names:
-
-            ```python
-            for m in AlignmentMetric.read(
-                Path("out.tsv"),
-                fieldnames=["read_name", "mapping_quality"],
-            ):
-                print(m.read_name, m.mapping_quality)
-            ```
-        """
-        with MetricReader.open(
-            cls,
-            path,
-            delimiter=delimiter,
-            fieldnames=fieldnames,
-            encoding=encoding,
-        ) as reader:
-            yield from reader
 
     # NB: "Before" validators (mode="before") run before field validators such as
     # `DelimitedList._split_lists()`. Empty strings in Optional fields will always be converted to
@@ -163,8 +93,8 @@ class Metric(
         the model's field names when aliases are used.
 
         Note:
-            This method is deliberately not used during reading/validation; see `read()` for
-            the headerless-input path.
+            This method is deliberately not used during reading/validation; see
+            `MetricReader` for the headerless-input path.
 
         Returns:
             The list of fieldnames to use as the header row.

--- a/tests/benchmarks/test_benchmark_runtime.py
+++ b/tests/benchmarks/test_benchmark_runtime.py
@@ -17,6 +17,7 @@ NUM_ROWS: list[str] = ["1e4", "1e5"]
 @pytest.mark.parametrize("num_rows", NUM_ROWS)
 def test_fgmetric(benchmark: BenchmarkFixture, benchmark_data: Path, num_rows: str) -> None:
     from fgmetric import Metric
+    from fgmetric import MetricReader
 
     class DemoMetric(Metric):
         foo: int
@@ -28,7 +29,11 @@ def test_fgmetric(benchmark: BenchmarkFixture, benchmark_data: Path, num_rows: s
 
     tsv = benchmark_data / f"demo.{num_rows}.tsv"
 
-    benchmark(lambda: list(DemoMetric.read(tsv)))
+    def read_all() -> list[DemoMetric]:
+        with MetricReader.open(DemoMetric, tsv) as reader:
+            return list(reader)
+
+    benchmark(read_all)
 
 
 @pytest.mark.skipif(not HAS_FGPYO, reason="fgpyo not installed")

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import PlainSerializer
 
 from fgmetric import Metric
+from fgmetric import MetricReader
 from fgmetric import MetricWriter
 
 
@@ -28,7 +29,8 @@ def test_comma_delimited_list(tmp_path: Path) -> None:
         fout.write("Nils\t1,2,3\n")
         fout.write("Tim\t\n")
 
-    metrics = list(FakeMetric.read(fpath_to_read))
+    with MetricReader.open(FakeMetric, fpath_to_read) as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 2
     assert metrics[0].name == "Nils"
@@ -65,7 +67,8 @@ def test_other_delimited_list(tmp_path: Path) -> None:
         fout.write("name\tvalues\n")
         fout.write("Tim\t1;2;3\n")
 
-    metrics = list(FakeMetric.read(fpath_to_read))
+    with MetricReader.open(FakeMetric, fpath_to_read) as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 1
     assert metrics[0].name == "Tim"
@@ -121,7 +124,8 @@ def test_delimited_list_with_optional_field(tmp_path: Path) -> None:
         fout.write("Nils\t\n")
         fout.write("Tim\t1,2,3\n")
 
-    metrics = list(FakeMetric.read(fpath_to_read))
+    with MetricReader.open(FakeMetric, fpath_to_read) as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 2
     assert metrics[0].name == "Nils"
@@ -183,7 +187,8 @@ def test_counter_pivot_table_of_enum(tmp_path: Path) -> None:
         fout.write("name\tfoo\tbar\n")
         fout.write("Nils\t1\t2\n")
 
-    metrics = list(FakeMetric.read(fpath_to_read))
+    with MetricReader.open(FakeMetric, fpath_to_read) as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 1
     metric = metrics[0]
@@ -241,7 +246,8 @@ def test_counter_pivot_table_missing_enum_members_default_to_zero(tmp_path: Path
         fout.write("name\tfoo\n")
         fout.write("test\t5\n")
 
-    metrics = list(FakeMetric.read(fpath))
+    with MetricReader.open(FakeMetric, fpath) as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 1
     metric = metrics[0]

--- a/tests/test_metric_reader.py
+++ b/tests/test_metric_reader.py
@@ -161,7 +161,8 @@ def test_read_tsv(tmp_path: Path) -> None:
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\nfoo\t1\n")
 
-    metrics = list(SimpleMetric.read(fpath))
+    with MetricReader.open(SimpleMetric, fpath) as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 1
     assert metrics[0].name == "foo"
@@ -173,7 +174,8 @@ def test_read_csv(tmp_path: Path) -> None:
     fpath = tmp_path / "metrics.csv"
     fpath.write_text("name,count\nfoo,1\n")
 
-    metrics = list(SimpleMetric.read(fpath, delimiter=","))
+    with MetricReader.open(SimpleMetric, fpath, delimiter=",") as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 1
     assert metrics[0].name == "foo"
@@ -181,13 +183,14 @@ def test_read_csv(tmp_path: Path) -> None:
 
 
 def test_read_yields_correct_type(tmp_path: Path) -> None:
-    """Test that read() yields instances of the correct Metric subclass."""
+    """Test that MetricReader yields instances of the correct Metric subclass."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\nfoo\t1\n")
 
-    for metric in SimpleMetric.read(fpath):
-        assert_type(metric, SimpleMetric)
-        assert isinstance(metric, SimpleMetric)
+    with MetricReader.open(SimpleMetric, fpath) as reader:
+        for metric in reader:
+            assert_type(metric, SimpleMetric)
+            assert isinstance(metric, SimpleMetric)
 
 
 def test_read_multiple_rows(tmp_path: Path) -> None:
@@ -195,7 +198,8 @@ def test_read_multiple_rows(tmp_path: Path) -> None:
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\nfoo\t1\nbar\t2\nbaz\t3\n")
 
-    metrics = list(SimpleMetric.read(fpath))
+    with MetricReader.open(SimpleMetric, fpath) as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 3
     assert metrics[0].name == "foo"
@@ -216,7 +220,8 @@ def test_read_coerces_string_to_int(tmp_path: Path) -> None:
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\nfoo\t42\n")
 
-    metrics = list(SimpleMetric.read(fpath))
+    with MetricReader.open(SimpleMetric, fpath) as reader:
+        metrics = list(reader)
 
     assert metrics[0].count == 42
     assert isinstance(metrics[0].count, int)
@@ -227,7 +232,8 @@ def test_read_coerces_string_to_float(tmp_path: Path) -> None:
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tscore\nfoo\t3.14\n")
 
-    metrics = list(MetricWithFloat.read(fpath))
+    with MetricReader.open(MetricWithFloat, fpath) as reader:
+        metrics = list(reader)
 
     assert metrics[0].score == pytest.approx(3.14)
     assert isinstance(metrics[0].score, float)
@@ -238,7 +244,8 @@ def test_read_coerces_string_to_bool(tmp_path: Path) -> None:
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tis_active\nfoo\ttrue\nbar\tfalse\n")
 
-    metrics = list(MetricWithBool.read(fpath))
+    with MetricReader.open(MetricWithBool, fpath) as reader:
+        metrics = list(reader)
 
     assert metrics[0].is_active is True
     assert metrics[1].is_active is False
@@ -254,7 +261,8 @@ def test_read_empty_field_becomes_none(tmp_path: Path) -> None:
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tvalue\nfoo\t\n")
 
-    metrics = list(MetricWithOptional.read(fpath))
+    with MetricReader.open(MetricWithOptional, fpath) as reader:
+        metrics = list(reader)
 
     assert metrics[0].value is None
 
@@ -264,7 +272,8 @@ def test_read_empty_field_with_optional_type(tmp_path: Path) -> None:
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tvalue\nfoo\t\nbar\t42\n")
 
-    metrics = list(MetricWithOptional.read(fpath))
+    with MetricReader.open(MetricWithOptional, fpath) as reader:
+        metrics = list(reader)
 
     assert metrics[0].value is None
     assert metrics[1].value == 42
@@ -276,7 +285,8 @@ def test_read_empty_field_with_required_type_raises(tmp_path: Path) -> None:
     fpath.write_text("name\tcount\nfoo\t\n")
 
     with pytest.raises(ValidationError):
-        list(SimpleMetric.read(fpath))
+        with MetricReader.open(SimpleMetric, fpath) as reader:
+            list(reader)
 
 
 # ======================================================================================
@@ -290,7 +300,8 @@ def test_read_handles_utf8_bom(tmp_path: Path) -> None:
     # Write file with BOM prefix
     fpath.write_bytes(b"\xef\xbb\xbfname\tcount\nfoo\t1\n")
 
-    metrics = list(SimpleMetric.read(fpath))
+    with MetricReader.open(SimpleMetric, fpath) as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 1
     assert metrics[0].name == "foo"
@@ -308,7 +319,8 @@ def test_read_with_field_alias(tmp_path: Path) -> None:
     # Header uses alias "count" instead of field name "read_count"
     fpath.write_text("name\tcount\nfoo\t100\n")
 
-    metrics = list(MetricWithAlias.read(fpath))
+    with MetricReader.open(MetricWithAlias, fpath) as reader:
+        metrics = list(reader)
 
     assert metrics[0].name == "foo"
     assert metrics[0].read_count == 100
@@ -324,29 +336,19 @@ def test_read_empty_file_no_rows(tmp_path: Path) -> None:
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\n")
 
-    metrics = list(SimpleMetric.read(fpath))
+    with MetricReader.open(SimpleMetric, fpath) as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 0
 
 
-def test_read_returns_iterator(tmp_path: Path) -> None:
-    """Test that read() returns an iterator, not a list."""
-    fpath = tmp_path / "metrics.tsv"
-    fpath.write_text("name\tcount\nfoo\t1\n")
-
-    result = SimpleMetric.read(fpath)
-
-    # Should be an iterator/generator, not a list
-    assert hasattr(result, "__iter__")
-    assert hasattr(result, "__next__")
-
-
 def test_read_file_not_found_raises(tmp_path: Path) -> None:
-    """Test that reading a non-existent file raises FileNotFoundError."""
+    """Test that opening a non-existent file raises FileNotFoundError."""
     fpath = tmp_path / "does_not_exist.tsv"
 
     with pytest.raises(FileNotFoundError):
-        list(SimpleMetric.read(fpath))
+        with MetricReader.open(SimpleMetric, fpath):
+            pass
 
 
 # ======================================================================================
@@ -361,7 +363,8 @@ def test_read_missing_required_field_raises(tmp_path: Path) -> None:
     fpath.write_text("name\nfoo\n")
 
     with pytest.raises(ValidationError):
-        list(SimpleMetric.read(fpath))
+        with MetricReader.open(SimpleMetric, fpath) as reader:
+            list(reader)
 
 
 def test_read_invalid_type_raises(tmp_path: Path) -> None:
@@ -370,7 +373,8 @@ def test_read_invalid_type_raises(tmp_path: Path) -> None:
     fpath.write_text("name\tcount\nfoo\tnot_an_int\n")
 
     with pytest.raises(ValidationError):
-        list(SimpleMetric.read(fpath))
+        with MetricReader.open(SimpleMetric, fpath) as reader:
+            list(reader)
 
 
 def test_read_extra_columns_ignored(tmp_path: Path) -> None:
@@ -378,7 +382,8 @@ def test_read_extra_columns_ignored(tmp_path: Path) -> None:
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\textra\nfoo\t1\tignored\n")
 
-    metrics = list(SimpleMetric.read(fpath))
+    with MetricReader.open(SimpleMetric, fpath) as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 1
     assert metrics[0].name == "foo"
@@ -397,7 +402,8 @@ def test_read_headerless_with_fieldnames(tmp_path: Path) -> None:
     # Three data rows, no header
     fpath.write_text("foo\t1\nbar\t2\nbaz\t3\n")
 
-    metrics = list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+    with MetricReader.open(SimpleMetric, fpath, fieldnames=["name", "count"]) as reader:
+        metrics = list(reader)
 
     assert [m.name for m in metrics] == ["foo", "bar", "baz"]
     assert [m.count for m in metrics] == [1, 2, 3]
@@ -408,7 +414,8 @@ def test_read_headerless_with_alias(tmp_path: Path) -> None:
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("foo\t100\n")
 
-    metrics = list(MetricWithAlias.read(fpath, fieldnames=["name", "count"]))
+    with MetricReader.open(MetricWithAlias, fpath, fieldnames=["name", "count"]) as reader:
+        metrics = list(reader)
 
     assert metrics[0].name == "foo"
     assert metrics[0].read_count == 100
@@ -420,7 +427,8 @@ def test_read_headerless_missing_required_field_raises(tmp_path: Path) -> None:
     fpath.write_text("foo\n")
 
     with pytest.raises(ValidationError):
-        list(SimpleMetric.read(fpath, fieldnames=["name"]))
+        with MetricReader.open(SimpleMetric, fpath, fieldnames=["name"]) as reader:
+            list(reader)
 
 
 def test_read_headerless_row_missing_column_raises(tmp_path: Path) -> None:
@@ -430,7 +438,8 @@ def test_read_headerless_row_missing_column_raises(tmp_path: Path) -> None:
     fpath.write_text("foo\n")
 
     with pytest.raises(ValidationError):
-        list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+        with MetricReader.open(SimpleMetric, fpath, fieldnames=["name", "count"]) as reader:
+            list(reader)
 
 
 def test_read_headerless_short_row_among_valid_rows_raises(tmp_path: Path) -> None:
@@ -440,7 +449,8 @@ def test_read_headerless_short_row_among_valid_rows_raises(tmp_path: Path) -> No
     fpath.write_text("foo\t1\nbar\nbaz\t3\n")
 
     with pytest.raises(ValidationError):
-        list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+        with MetricReader.open(SimpleMetric, fpath, fieldnames=["name", "count"]) as reader:
+            list(reader)
 
 
 def test_read_headerless_row_extra_column_ignored(tmp_path: Path) -> None:
@@ -449,7 +459,8 @@ def test_read_headerless_row_extra_column_ignored(tmp_path: Path) -> None:
     # Row has an extra value not covered by fieldnames
     fpath.write_text("foo\t1\textra\n")
 
-    metrics = list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+    with MetricReader.open(SimpleMetric, fpath, fieldnames=["name", "count"]) as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 1
     assert metrics[0].name == "foo"
@@ -463,7 +474,8 @@ def test_read_headerless_detects_header_row_raises(tmp_path: Path) -> None:
     fpath.write_text("name\tcount\nfoo\t1\n")
 
     with pytest.raises(ValueError, match="header"):
-        list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+        with MetricReader.open(SimpleMetric, fpath, fieldnames=["name", "count"]):
+            pass
 
 
 def test_read_headerless_first_row_coincidentally_matching_value_is_data(
@@ -473,7 +485,8 @@ def test_read_headerless_first_row_coincidentally_matching_value_is_data(
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\t1\nbar\t2\n")
 
-    metrics = list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+    with MetricReader.open(SimpleMetric, fpath, fieldnames=["name", "count"]) as reader:
+        metrics = list(reader)
 
     assert [m.name for m in metrics] == ["name", "bar"]
     assert [m.count for m in metrics] == [1, 2]
@@ -487,7 +500,8 @@ def test_read_headerless_detects_header_row_with_aliased_field_raises(tmp_path: 
     fpath.write_text("name\tcount\nfoo\t1\n")
 
     with pytest.raises(ValueError, match="header"):
-        list(MetricWithAlias.read(fpath, fieldnames=["name", "count"]))
+        with MetricReader.open(MetricWithAlias, fpath, fieldnames=["name", "count"]):
+            pass
 
 
 def test_read_headerless_empty_file(tmp_path: Path) -> None:
@@ -495,7 +509,8 @@ def test_read_headerless_empty_file(tmp_path: Path) -> None:
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("")
 
-    metrics = list(SimpleMetric.read(fpath, fieldnames=["name", "count"]))
+    with MetricReader.open(SimpleMetric, fpath, fieldnames=["name", "count"]) as reader:
+        metrics = list(reader)
 
     assert metrics == []
 
@@ -516,7 +531,8 @@ def test_read_parent_class_discards_subclass_fields(tmp_path: Path) -> None:
     # File has columns for ChildMetric but we read with ParentMetric
     fpath.write_text("name\tvalue\textra_field\tanother_field\nfoo\t42\textra\t99\n")
 
-    metrics = list(ParentMetric.read(fpath))
+    with MetricReader.open(ParentMetric, fpath) as reader:
+        metrics = list(reader)
 
     assert len(metrics) == 1
     assert metrics[0].name == "foo"
@@ -526,8 +542,9 @@ def test_read_parent_class_discards_subclass_fields(tmp_path: Path) -> None:
 
 
 def test_read_respects_encoding(tmp_path: Path) -> None:
-    """Test that Metric.read forwards the encoding kwarg to MetricReader.open."""
+    """Test that MetricReader.open decodes the file with the specified encoding."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_bytes("name\tcount\nrené\t1\n".encode("latin-1"))
-    metrics = list(SimpleMetric.read(fpath, encoding="latin-1"))
+    with MetricReader.open(SimpleMetric, fpath, encoding="latin-1") as reader:
+        metrics = list(reader)
     assert metrics == [SimpleMetric(name="rené", count=1)]

--- a/tests/test_metric_reader.py
+++ b/tests/test_metric_reader.py
@@ -156,7 +156,7 @@ class ChildMetric(ParentMetric):
 # ======================================================================================
 
 
-def test_read_tsv(tmp_path: Path) -> None:
+def test_open_tsv(tmp_path: Path) -> None:
     """Test reading metrics from a TSV file."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\nfoo\t1\n")
@@ -169,7 +169,7 @@ def test_read_tsv(tmp_path: Path) -> None:
     assert metrics[0].count == 1
 
 
-def test_read_csv(tmp_path: Path) -> None:
+def test_open_csv(tmp_path: Path) -> None:
     """Test reading metrics with comma delimiter."""
     fpath = tmp_path / "metrics.csv"
     fpath.write_text("name,count\nfoo,1\n")
@@ -182,7 +182,7 @@ def test_read_csv(tmp_path: Path) -> None:
     assert metrics[0].count == 1
 
 
-def test_read_yields_correct_type(tmp_path: Path) -> None:
+def test_open_yields_correct_type(tmp_path: Path) -> None:
     """Test that MetricReader yields instances of the correct Metric subclass."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\nfoo\t1\n")
@@ -193,7 +193,7 @@ def test_read_yields_correct_type(tmp_path: Path) -> None:
             assert isinstance(metric, SimpleMetric)
 
 
-def test_read_multiple_rows(tmp_path: Path) -> None:
+def test_open_multiple_rows(tmp_path: Path) -> None:
     """Test reading a file with multiple metric rows."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\nfoo\t1\nbar\t2\nbaz\t3\n")
@@ -215,7 +215,7 @@ def test_read_multiple_rows(tmp_path: Path) -> None:
 # ======================================================================================
 
 
-def test_read_coerces_string_to_int(tmp_path: Path) -> None:
+def test_open_coerces_string_to_int(tmp_path: Path) -> None:
     """Test that string values are coerced to int fields."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\nfoo\t42\n")
@@ -227,7 +227,7 @@ def test_read_coerces_string_to_int(tmp_path: Path) -> None:
     assert isinstance(metrics[0].count, int)
 
 
-def test_read_coerces_string_to_float(tmp_path: Path) -> None:
+def test_open_coerces_string_to_float(tmp_path: Path) -> None:
     """Test that string values are coerced to float fields."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tscore\nfoo\t3.14\n")
@@ -239,7 +239,7 @@ def test_read_coerces_string_to_float(tmp_path: Path) -> None:
     assert isinstance(metrics[0].score, float)
 
 
-def test_read_coerces_string_to_bool(tmp_path: Path) -> None:
+def test_open_coerces_string_to_bool(tmp_path: Path) -> None:
     """Test that string values like 'true'/'false' are coerced to bool."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tis_active\nfoo\ttrue\nbar\tfalse\n")
@@ -256,7 +256,7 @@ def test_read_coerces_string_to_bool(tmp_path: Path) -> None:
 # ======================================================================================
 
 
-def test_read_empty_field_becomes_none(tmp_path: Path) -> None:
+def test_open_empty_field_becomes_none(tmp_path: Path) -> None:
     """Test that empty string fields are converted to None."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tvalue\nfoo\t\n")
@@ -267,7 +267,7 @@ def test_read_empty_field_becomes_none(tmp_path: Path) -> None:
     assert metrics[0].value is None
 
 
-def test_read_empty_field_with_optional_type(tmp_path: Path) -> None:
+def test_open_empty_field_with_optional_type(tmp_path: Path) -> None:
     """Test that empty fields work with Optional[T] annotations."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tvalue\nfoo\t\nbar\t42\n")
@@ -279,7 +279,7 @@ def test_read_empty_field_with_optional_type(tmp_path: Path) -> None:
     assert metrics[1].value == 42
 
 
-def test_read_empty_field_with_required_type_raises(tmp_path: Path) -> None:
+def test_open_empty_field_with_required_type_raises(tmp_path: Path) -> None:
     """Test that empty fields on required (non-Optional) fields raise ValidationError."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\nfoo\t\n")
@@ -294,7 +294,7 @@ def test_read_empty_field_with_required_type_raises(tmp_path: Path) -> None:
 # ======================================================================================
 
 
-def test_read_handles_utf8_bom(tmp_path: Path) -> None:
+def test_open_handles_utf8_bom(tmp_path: Path) -> None:
     """Test that UTF-8 BOM is stripped from file header."""
     fpath = tmp_path / "metrics.tsv"
     # Write file with BOM prefix
@@ -313,7 +313,7 @@ def test_read_handles_utf8_bom(tmp_path: Path) -> None:
 # ======================================================================================
 
 
-def test_read_with_field_alias(tmp_path: Path) -> None:
+def test_open_with_field_alias(tmp_path: Path) -> None:
     """Test reading a file where headers match field aliases."""
     fpath = tmp_path / "metrics.tsv"
     # Header uses alias "count" instead of field name "read_count"
@@ -331,7 +331,7 @@ def test_read_with_field_alias(tmp_path: Path) -> None:
 # ======================================================================================
 
 
-def test_read_empty_file_no_rows(tmp_path: Path) -> None:
+def test_open_empty_file_no_rows(tmp_path: Path) -> None:
     """Test reading a file with only a header row (no data)."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\n")
@@ -342,7 +342,7 @@ def test_read_empty_file_no_rows(tmp_path: Path) -> None:
     assert len(metrics) == 0
 
 
-def test_read_file_not_found_raises(tmp_path: Path) -> None:
+def test_open_file_not_found_raises(tmp_path: Path) -> None:
     """Test that opening a non-existent file raises FileNotFoundError."""
     fpath = tmp_path / "does_not_exist.tsv"
 
@@ -356,7 +356,7 @@ def test_read_file_not_found_raises(tmp_path: Path) -> None:
 # ======================================================================================
 
 
-def test_read_missing_required_field_raises(tmp_path: Path) -> None:
+def test_open_missing_required_field_raises(tmp_path: Path) -> None:
     """Test that missing required fields raise ValidationError."""
     fpath = tmp_path / "metrics.tsv"
     # Missing "count" column
@@ -367,7 +367,7 @@ def test_read_missing_required_field_raises(tmp_path: Path) -> None:
             list(reader)
 
 
-def test_read_invalid_type_raises(tmp_path: Path) -> None:
+def test_open_invalid_type_raises(tmp_path: Path) -> None:
     """Test that values that can't be coerced raise ValidationError."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\nfoo\tnot_an_int\n")
@@ -377,7 +377,7 @@ def test_read_invalid_type_raises(tmp_path: Path) -> None:
             list(reader)
 
 
-def test_read_extra_columns_ignored(tmp_path: Path) -> None:
+def test_open_extra_columns_ignored(tmp_path: Path) -> None:
     """Test that extra columns in the file are ignored."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("name\tcount\textra\nfoo\t1\tignored\n")
@@ -396,7 +396,7 @@ def test_read_extra_columns_ignored(tmp_path: Path) -> None:
 # ======================================================================================
 
 
-def test_read_headerless_with_fieldnames(tmp_path: Path) -> None:
+def test_open_headerless_with_fieldnames(tmp_path: Path) -> None:
     """Reading a headerless TSV with `fieldnames` treats every row as data."""
     fpath = tmp_path / "metrics.tsv"
     # Three data rows, no header
@@ -409,7 +409,7 @@ def test_read_headerless_with_fieldnames(tmp_path: Path) -> None:
     assert [m.count for m in metrics] == [1, 2, 3]
 
 
-def test_read_headerless_with_alias(tmp_path: Path) -> None:
+def test_open_headerless_with_alias(tmp_path: Path) -> None:
     """`fieldnames` may reference a field's alias, mirroring header-based reading."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("foo\t100\n")
@@ -421,7 +421,7 @@ def test_read_headerless_with_alias(tmp_path: Path) -> None:
     assert metrics[0].read_count == 100
 
 
-def test_read_headerless_missing_required_field_raises(tmp_path: Path) -> None:
+def test_open_headerless_missing_required_field_raises(tmp_path: Path) -> None:
     """A headerless file missing a required field still raises ValidationError."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("foo\n")
@@ -431,7 +431,7 @@ def test_read_headerless_missing_required_field_raises(tmp_path: Path) -> None:
             list(reader)
 
 
-def test_read_headerless_row_missing_column_raises(tmp_path: Path) -> None:
+def test_open_headerless_row_missing_column_raises(tmp_path: Path) -> None:
     """When a row has fewer values than `fieldnames`, missing required fields raises."""
     fpath = tmp_path / "metrics.tsv"
     # Row only has "name", "count" is missing
@@ -442,7 +442,7 @@ def test_read_headerless_row_missing_column_raises(tmp_path: Path) -> None:
             list(reader)
 
 
-def test_read_headerless_short_row_among_valid_rows_raises(tmp_path: Path) -> None:
+def test_open_headerless_short_row_among_valid_rows_raises(tmp_path: Path) -> None:
     """A single short row among otherwise-valid rows still raises ValidationError."""
     fpath = tmp_path / "metrics.tsv"
     # The middle row is missing the "count" value
@@ -453,7 +453,7 @@ def test_read_headerless_short_row_among_valid_rows_raises(tmp_path: Path) -> No
             list(reader)
 
 
-def test_read_headerless_row_extra_column_ignored(tmp_path: Path) -> None:
+def test_open_headerless_row_extra_column_ignored(tmp_path: Path) -> None:
     """When a row has more values than `fieldnames`, the extras are ignored."""
     fpath = tmp_path / "metrics.tsv"
     # Row has an extra value not covered by fieldnames
@@ -467,7 +467,7 @@ def test_read_headerless_row_extra_column_ignored(tmp_path: Path) -> None:
     assert metrics[0].count == 1
 
 
-def test_read_headerless_detects_header_row_raises(tmp_path: Path) -> None:
+def test_open_headerless_detects_header_row_raises(tmp_path: Path) -> None:
     """Passing `fieldnames` for a file that already has a matching header row raises."""
     fpath = tmp_path / "metrics.tsv"
     # File has a real header row that matches the supplied fieldnames
@@ -478,7 +478,7 @@ def test_read_headerless_detects_header_row_raises(tmp_path: Path) -> None:
             pass
 
 
-def test_read_headerless_first_row_coincidentally_matching_value_is_data(
+def test_open_headerless_first_row_coincidentally_matching_value_is_data(
     tmp_path: Path,
 ) -> None:
     """A single field whose value happens to match its fieldname is not flagged."""
@@ -492,7 +492,7 @@ def test_read_headerless_first_row_coincidentally_matching_value_is_data(
     assert [m.count for m in metrics] == [1, 2]
 
 
-def test_read_headerless_detects_header_row_with_aliased_field_raises(tmp_path: Path) -> None:
+def test_open_headerless_detects_header_row_with_aliased_field_raises(tmp_path: Path) -> None:
     """Header detection compares against supplied fieldnames, not model field names."""
     fpath = tmp_path / "metrics.tsv"
     # `MetricWithAlias` declares `read_count` aliased to "count"; the supplied fieldnames
@@ -504,7 +504,7 @@ def test_read_headerless_detects_header_row_with_aliased_field_raises(tmp_path: 
             pass
 
 
-def test_read_headerless_empty_file(tmp_path: Path) -> None:
+def test_open_headerless_empty_file(tmp_path: Path) -> None:
     """An empty headerless file yields no metrics and does not raise."""
     fpath = tmp_path / "metrics.tsv"
     fpath.write_text("")
@@ -520,7 +520,7 @@ def test_read_headerless_empty_file(tmp_path: Path) -> None:
 # ======================================================================================
 
 
-def test_read_parent_class_discards_subclass_fields(tmp_path: Path) -> None:
+def test_open_parent_class_discards_subclass_fields(tmp_path: Path) -> None:
     """
     Test that reading with parent class discards extra subclass fields.
 
@@ -539,12 +539,3 @@ def test_read_parent_class_discards_subclass_fields(tmp_path: Path) -> None:
     assert metrics[0].value == 42
     assert not hasattr(metrics[0], "extra_field")
     assert not hasattr(metrics[0], "another_field")
-
-
-def test_read_respects_encoding(tmp_path: Path) -> None:
-    """Test that MetricReader.open decodes the file with the specified encoding."""
-    fpath = tmp_path / "metrics.tsv"
-    fpath.write_bytes("name\tcount\nrené\t1\n".encode("latin-1"))
-    with MetricReader.open(SimpleMetric, fpath, encoding="latin-1") as reader:
-        metrics = list(reader)
-    assert metrics == [SimpleMetric(name="rené", count=1)]


### PR DESCRIPTION
## Summary

Removes `Metric.read()`, replaced by `MetricReader.open()`. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the legacy class-level reader; please use the new MetricReader.open() context manager to read metric files.
  * Documentation and examples updated to demonstrate the new context-manager API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/fgmetric/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->