### PR TITLE
docs: refresh README and CHANGELOG for the new reader/writer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,69 +4,44 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### 💥 Breaking Changes
-
-- Remove `Metric.read()` — read metrics via `MetricReader.open()` instead (#49)
-- `MetricWriter` is IO-first; open a path with `MetricWriter.open()` rather than passing it to the constructor (#42)
-
-### 🚀 Features
+### Added
 
 - Introduce `MetricReader` for iterating metrics from any text-IO source (#41)
 - Add an `encoding` kwarg on `MetricReader.open` and `MetricWriter.open` (#43)
 - Transparent gzip/bz2/xz support via `xopen` (#44)
 
+### Changed
+
+- Remove `Metric.read()` — read metrics via `MetricReader.open()` instead (#49)
+- `MetricWriter` is IO-first; open a path with `MetricWriter.open()` rather than passing it to the constructor (#42)
+
 ## [0.3.0] - 2026-05-12
 
-### 🚀 Features
+### Added
 
 - Expose `fieldnames` arg in `Metric.read` (#38)
 
-### 🐛 Bug Fixes
-
-- Update repository URLs to fg-labs after org transfer (#32)
-
-### 📚 Documentation
-
-- Add Fulcrum Genomics branding to README (#33)
-
 ## [0.2.0] - 2026-03-13
 
-### 🐛 Bug Fixes
+### Fixed
 
 - Fix file handle leak in MetricWriter.__init__ (#24)
 - Use JSON mode for model serialization in MetricWriter (#25)
 - Specify UTF-8 encoding when opening output files (#26)
 - Shallow copy input dict in `_empty_field_to_none` validator (#28)
 
-### 🚜 Refactor
+### Changed
 
 - Improve error messages in CounterPivotTable and DelimitedList (#27)
 - Modernize type annotations (#29)
 
-### 📚 Documentation
-
-- Add examples to docstrings (#30)
-
 ## [0.1.0] - 2026-01-22
 
-### 🚀 Features
+### Added
 
+- Initial release.
 - Metric and MetricWriter (#6)
 - Benchmarking (#7)
 - Typing helpers (#2)
-- Delimited lists (#1)
-- CounterPivotTable (#3)
-
-### 🚜 Refactor
-
-- Minor cleanups (#11)
-
-### 📚 Documentation
-
-- Update README (#14)
-
-### ⚙️ Miscellaneous Tasks
-
-- Publish workflow (#13)
-- Clean up toolkit and add updates from template (#5)
-- Configure pre-push hook (#12)
+- Delimited lists mixin (#1)
+- CounterPivotTable mixin (#3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Remove `Metric.read()` — read metrics via `MetricReader.open()` instead (#49)
 - `MetricWriter` is IO-first; open a path with `MetricWriter.open()` rather than passing it to the constructor (#42)
+
+### Removed
+
+- Remove `Metric.read()` — read metrics via `MetricReader.open()` instead (#49)
 
 ## [0.3.0] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 💥 Breaking Changes
+
+- Remove `Metric.read()` — read metrics via `MetricReader.open()` instead (#49)
+- `MetricWriter` is IO-first; open a path with `MetricWriter.open()` rather than passing it to the constructor (#42)
+
+### 🚀 Features
+
+- Introduce `MetricReader` for iterating metrics from any text-IO source (#41)
+- Add an `encoding` kwarg on `MetricReader.open` and `MetricWriter.open` (#43)
+- Transparent gzip/bz2/xz support via `xopen` (#44)
+
 ## [0.3.0] - 2026-05-12
 
 ### 🚀 Features

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ with MetricReader.open(AlignmentMetric, path) as reader:
 Define a class to represent each row:
 
 ```python
-from pathlib import Path
 from fgmetric import Metric, MetricReader, MetricWriter
 
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ with open("metrics.tsv") as f:
 `fgmetric` replaces this with:
 
 ```py
-for metric in AlignmentMetric.read(path):
-    # metric.mapping_quality is already an int
-    # metric.is_duplicate is already a bool
-    # metric.score is already Optional[float]
+with MetricReader.open(AlignmentMetric, path) as reader:
+    for metric in reader:
+        # metric.mapping_quality is already an int
+        # metric.is_duplicate is already a bool
+        # metric.score is already Optional[float]
 ```
 
 **How it compares:**
@@ -79,7 +80,7 @@ Define a class to represent each row:
 
 ```python
 from pathlib import Path
-from fgmetric import Metric, MetricWriter
+from fgmetric import Metric, MetricReader, MetricWriter
 
 
 class AlignmentMetric(Metric):
@@ -92,15 +93,16 @@ Then read or write:
 
 ```python
 # Reading
-for metric in AlignmentMetric.read(Path("alignments.tsv")):
-    print(f"{metric.read_name}: MQ={metric.mapping_quality}")
+with MetricReader.open(AlignmentMetric, Path("alignments.tsv")) as reader:
+    for metric in reader:
+        print(f"{metric.read_name}: MQ={metric.mapping_quality}")
 
 # Writing
 metrics = [
     AlignmentMetric(read_name="read1", mapping_quality=60),
     AlignmentMetric(read_name="read2", mapping_quality=30, is_duplicate=True),
 ]
-with MetricWriter(AlignmentMetric, Path("output.tsv")) as writer:
+with MetricWriter.open(AlignmentMetric, Path("output.tsv")) as writer:
     writer.writeall(metrics)
 ```
 
@@ -122,13 +124,31 @@ Both reading and writing support custom delimiters for working with CSV or other
 
 ```python
 # Reading CSV files
-for metric in MyMetric.read(Path("data.csv"), delimiter=","):
-    ...
+with MetricReader.open(MyMetric, Path("data.csv"), delimiter=",") as reader:
+    for metric in reader:
+        ...
 
 # Writing CSV files
-with MetricWriter(MyMetric, Path("output.csv"), delimiter=",") as writer:
+with MetricWriter.open(MyMetric, Path("output.csv"), delimiter=",") as writer:
     ...
 ```
+
+### Compression
+
+Reading and writing transparently handle gzip, bzip2, and xz files based on the path extension (via [xopen](https://github.com/pycompression/xopen)):
+
+```python
+with MetricReader.open(AlignmentMetric, Path("alignments.tsv.gz")) as reader:
+    for metric in reader:
+        ...
+
+with MetricWriter.open(AlignmentMetric, Path("output.tsv.bz2")) as writer:
+    writer.writeall(metrics)
+```
+
+### Text Encoding
+
+Both `MetricReader.open` and `MetricWriter.open` accept an `encoding` kwarg. Reading defaults to `utf-8-sig`, which cleanly opens Excel-generated CSVs by stripping a UTF-8 BOM if present.
 
 ### List Fields
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ with MetricReader.open(AlignmentMetric, path) as reader:
 ```
 
 **How it compares:**
-- **vs. csv + dataclasses** — Automatic type coercion and validation without boilerplate. Built on Pydantic, so additional custom validators and serializer can be readily added.
+- **vs. csv + dataclasses** — Automatic type coercion and validation without boilerplate. Built on Pydantic, so additional custom validators and serializers can be readily added.
 - **vs. pandas** — Unlike pandas, `fgmetric` processes records lazily — you can handle files larger than memory. And `Metric`s are type-validated and can be made immutable, making them safe to pass between functions without defensive copying.
 - **vs. Pydantic alone** — `fgmetric` handles CSV/TSV specifics (header parsing, delimiter configuration) and provides out-of-the box features like empty value handling and Counter field pivoting.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Then read or write:
 
 ```python
 # Reading
-with MetricReader.open(AlignmentMetric, Path("alignments.tsv")) as reader:
+with MetricReader.open(AlignmentMetric, "alignments.tsv") as reader:
     for metric in reader:
         print(f"{metric.read_name}: MQ={metric.mapping_quality}")
 
@@ -102,7 +102,7 @@ metrics = [
     AlignmentMetric(read_name="read1", mapping_quality=60),
     AlignmentMetric(read_name="read2", mapping_quality=30, is_duplicate=True),
 ]
-with MetricWriter.open(AlignmentMetric, Path("output.tsv")) as writer:
+with MetricWriter.open(AlignmentMetric, "output.tsv") as writer:
     writer.writeall(metrics)
 ```
 
@@ -124,12 +124,12 @@ Both reading and writing support custom delimiters for working with CSV or other
 
 ```python
 # Reading CSV files
-with MetricReader.open(MyMetric, Path("data.csv"), delimiter=",") as reader:
+with MetricReader.open(MyMetric, "data.csv", delimiter=",") as reader:
     for metric in reader:
         ...
 
 # Writing CSV files
-with MetricWriter.open(MyMetric, Path("output.csv"), delimiter=",") as writer:
+with MetricWriter.open(MyMetric, "output.csv", delimiter=",") as writer:
     ...
 ```
 
@@ -138,17 +138,13 @@ with MetricWriter.open(MyMetric, Path("output.csv"), delimiter=",") as writer:
 Reading and writing transparently handle gzip, bzip2, and xz files based on the path extension (via [xopen](https://github.com/pycompression/xopen)):
 
 ```python
-with MetricReader.open(AlignmentMetric, Path("alignments.tsv.gz")) as reader:
+with MetricReader.open(AlignmentMetric, "alignments.tsv.gz") as reader:
     for metric in reader:
         ...
 
-with MetricWriter.open(AlignmentMetric, Path("output.tsv.bz2")) as writer:
+with MetricWriter.open(AlignmentMetric, "output.tsv.bz2") as writer:
     writer.writeall(metrics)
 ```
-
-### Text Encoding
-
-Both `MetricReader.open` and `MetricWriter.open` accept an `encoding` kwarg. Reading defaults to `utf-8-sig`, which cleanly opens Excel-generated CSVs by stripping a UTF-8 BOM if present.
 
 ### List Fields
 

--- a/fgmetric/metric_reader.py
+++ b/fgmetric/metric_reader.py
@@ -20,7 +20,8 @@ class MetricReader[T: Metric]:
 
     Constructed with any iterable of strings (file handle, StringIO, list of
     lines). The reader does not own the source; callers manage its lifecycle.
-    Use the `open` classmethod to open and read a file in one step.
+    Use the `open` classmethod to open and read a file in one step; unlike direct
+    construction, `open` owns the file it opens and closes it on context exit.
     """
 
     _metric_class: type[T]
@@ -79,6 +80,10 @@ class MetricReader[T: Metric]:
         """
         Open `path` and yield a `MetricReader` over its contents.
 
+        This is a context manager: bind it in a `with` statement and iterate the reader it
+        yields. `reader = MetricReader.open(...)` without `with` binds the context manager
+        itself, not a reader, so it will not iterate.
+
         The file is opened with the given encoding and closed on context exit. The default encoding,
         `utf-8-sig`, will cleanly open Excel-generated CSVs by removing any UTF-8 BOM (if present).
 
@@ -96,6 +101,13 @@ class MetricReader[T: Metric]:
 
         Yields:
             A `MetricReader` over the opened file.
+
+        Example:
+            ```python
+            with MetricReader.open(AlignmentMetric, "metrics.txt") as reader:
+                for metric in reader:
+                    ...
+            ```
         """
         with xopen(path, mode="rt", encoding=encoding) as handle:
             yield cls(metric_class, handle, delimiter, fieldnames)

--- a/fgmetric/metric_writer.py
+++ b/fgmetric/metric_writer.py
@@ -17,7 +17,8 @@ class MetricWriter[T: Metric]:
 
     Construction takes a writable text IO and writes the header row immediately.
     The writer does not own the sink; callers manage its lifecycle. Use the
-    `open` classmethod to open and write to a file in one step.
+    `open` classmethod to open and write to a file in one step; unlike direct
+    construction, `open` owns the file it opens and closes it on context exit.
     """
 
     _metric_class: type[T]
@@ -61,6 +62,10 @@ class MetricWriter[T: Metric]:
         """
         Open `path` for writing and yield a `MetricWriter` over it.
 
+        This is a context manager: bind it in a `with` statement and write through the writer
+        it yields. `writer = MetricWriter.open(...)` without `with` binds the context manager
+        itself, not a writer.
+
         Compression is selected automatically based on the output file extension: plaintext, gzip
         (`.gz`), bzip2 (`.bz2`), or xz (`.xz`).
 
@@ -75,6 +80,12 @@ class MetricWriter[T: Metric]:
 
         Yields:
             A `MetricWriter` over the opened file.
+
+        Example:
+            ```python
+            with MetricWriter.open(AlignmentMetric, "metrics.txt") as writer:
+                writer.writeall(metrics)
+            ```
         """
         with xopen(path, mode="wt", encoding=encoding) as handle:
             yield cls(metric_class, handle, delimiter, lineterminator)


### PR DESCRIPTION
## Summary

Doc update. 

Updated the README to reflect the new `MetricReader`/`MetricWriter` API. Also de-slopped the CHANGELOG a bit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced MetricReader for reading metrics from files
  * Added encoding support for reader and writer operations
  * Added transparent compression support (gzip, bz2, xz)

* **Changed**
  * MetricWriter now uses IO-first API pattern with open() context manager

* **Removed**
  * Removed Metric.read() method; use MetricReader.open() instead

* **Documentation**
  * Updated examples and docstrings with new API usage patterns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/fgmetric/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->