### PR TITLE
chore: Bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name            = "fgmetric"
-version         = "0.3.0"
+version         = "0.4.0"
 description     = "Pydantic-backed Metric."
 readme          = "README.md"
 authors         = [{ name="Fulcrum Genomics LLC", email="contact@fulcrumgenomics.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "fgmetric"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Bump version from 0.3.0 to 0.4.0 (`pyproject.toml` + `uv.lock`).

Changes since 0.3.0:
- Introduce `MetricReader` for IO-based metric reading (#41)
- IO-first `MetricWriter` with `open()` classmethod (#42)
- `encoding` kwarg on path-opening classmethods (#43)
- Transparent gzip/bz2/xz support via `xopen` (#44)

## Test plan
- `poe check-all` passes locally (format, lint, mypy, 107 tests).
- After merge: tag `0.4.0` and push to trigger the publish workflow (builds, uploads to PyPI, generates the GitHub Release notes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->