### PR TITLE
fix: MetricWriter honors field aliases

### DIFF
--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -111,15 +111,19 @@ class Metric(
         # TODO: support returning the set of fields that would be constructed if the class has a
         # custom model serializer
 
+        # Resolve each field to the key it serializes under (its alias, when one is set), so the
+        # header matches the keys produced by `model_dump(by_alias=True)`. The Counter field, if
+        # present, is dropped here and replaced by its pivoted enum-member columns below.
         fieldnames: list[str]
-        fieldnames = list(cls.model_fields.keys())
+        fieldnames = [
+            info.serialization_alias or info.alias or name
+            for name, info in cls.model_fields.items()
+            if name != cls._counter_fieldname
+        ]
 
         if cls._counter_fieldname is None:
             # Short circuit if we don't have a Counter field
             return fieldnames
-
-        # Remove the declared Counter field
-        fieldnames = [f for f in fieldnames if f != cls._counter_fieldname]
 
         # Add the enum members
         assert cls._counter_enum is not None  # type narrowing

--- a/fgmetric/metric_writer.py
+++ b/fgmetric/metric_writer.py
@@ -97,7 +97,7 @@ class MetricWriter[T: Metric]:
         Args:
             metric: An instance of the writer's metric class.
         """
-        self._writer.writerow(metric.model_dump(mode="json"))
+        self._writer.writerow(metric.model_dump(mode="json", by_alias=True))
 
     def writeall(self, metrics: Iterable[T]) -> None:
         """

--- a/tests/test_metric_writer.py
+++ b/tests/test_metric_writer.py
@@ -93,7 +93,7 @@ def test_writer_uses_field_aliases() -> None:
 
     sink = StringIO()
     writer = MetricWriter(AliasMetric, sink)
-    # `read_count` must be populated via its alias; the writer emits that alias, not "read_count".
+    # `read_count` must be populated via its alias.
     writer.write(AliasMetric(name="foo", count=100))
     assert sink.getvalue() == "name\tcount\nfoo\t100\n"
 

--- a/tests/test_metric_writer.py
+++ b/tests/test_metric_writer.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import assert_type
 
 import pytest
+from pydantic import Field
 
 from fgmetric import Metric
 from fgmetric import MetricWriter
@@ -81,6 +82,20 @@ def test_writer_does_not_close_caller_handle() -> None:
     writer = MetricWriter(FakeMetric, sink)
     writer.write(FakeMetric(foo="abc", bar=1))
     assert not sink.closed
+
+
+def test_writer_uses_field_aliases() -> None:
+    """A field alias appears in both the header and the rows."""
+
+    class AliasMetric(Metric):
+        name: str
+        read_count: int = Field(alias="count")
+
+    sink = StringIO()
+    writer = MetricWriter(AliasMetric, sink)
+    # `read_count` must be populated via its alias; the writer emits that alias, not "read_count".
+    writer.write(AliasMetric(name="foo", count=100))
+    assert sink.getvalue() == "name\tcount\nfoo\t100\n"
 
 
 def test_writer_open_writes_header_and_rows(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Part of #18

`MetricWriter` ignored Pydantic field aliases: the header came from `model_fields` keys and rows from `model_dump()`, both of which use field names. `MetricReader` reads *by alias*, so an aliased metric written by `MetricWriter` could not be read back — the roundtrip raised `ValidationError`. 

`write()` now dumps with `by_alias=True` and `_header_fieldnames()` resolves each field to its serialization alias (falling back to the field name). 