### PR TITLE
fix: serialize absent Counter members as 0

### DIFF
--- a/fgmetric/collections/_counter_pivot_table.py
+++ b/fgmetric/collections/_counter_pivot_table.py
@@ -252,10 +252,13 @@ class CounterPivotTable(BaseModel):
             # Short circuit if we don't have a Counter field
             return data
 
-        # Replace the counter field with keys for each of its enum's members
+        # Replace the counter field with one column per enum member. Iterate the enum (not the
+        # Counter's own keys) so that members absent from the Counter are emitted as 0 rather than
+        # omitted; omitting them would leave the header's column empty and break read-back, which
+        # parses an empty cell as a missing integer.
+        assert self._counter_enum is not None  # not None iff _counter_fieldname is not None
         counts = data.pop(self._counter_fieldname)
-        for key, count in counts.items():
-            column_name = key if isinstance(key, str) else key.value
-            data[column_name] = count
+        for member in self._counter_enum:
+            data[member.value] = counts.get(member, 0)
 
         return data

--- a/fgmetric/collections/_counter_pivot_table.py
+++ b/fgmetric/collections/_counter_pivot_table.py
@@ -253,9 +253,7 @@ class CounterPivotTable(BaseModel):
             return data
 
         # Replace the counter field with one column per enum member. Iterate the enum (not the
-        # Counter's own keys) so that members absent from the Counter are emitted as 0 rather than
-        # omitted; omitting them would leave the header's column empty and break read-back, which
-        # parses an empty cell as a missing integer.
+        # Counter's own keys) so that members absent from the Counter are emitted as 0
         assert self._counter_enum is not None  # not None iff _counter_fieldname is not None
         counts = data.pop(self._counter_fieldname)
         for member in self._counter_enum:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -209,6 +209,35 @@ def test_counter_pivot_table_of_enum(tmp_path: Path) -> None:
             next(f)
 
 
+def test_counter_pivot_table_roundtrip_with_absent_member(tmp_path: Path) -> None:
+    """A Counter missing an enum member serializes that member as 0 and reads back cleanly."""
+
+    @unique
+    class FakeEnum(StrEnum):
+        FOO = "foo"
+        BAR = "bar"
+
+    class FakeMetric(Metric):
+        name: str
+        counts: Counter[FakeEnum]
+
+    # BAR is absent on construction; it must be written as 0, not as an empty cell. Otherwise the
+    # header's "bar" column is left empty on disk and read-back fails parsing "" as an int.
+    fpath = tmp_path / "test.txt"
+    writer: MetricWriter[FakeMetric]
+    with MetricWriter.open(FakeMetric, fpath) as writer:
+        writer.write(FakeMetric(name="Nils", counts=Counter({FakeEnum.FOO: 5})))
+
+    assert fpath.read_text() == "name\tfoo\tbar\nNils\t5\t0\n"
+
+    with MetricReader.open(FakeMetric, fpath) as reader:
+        metrics = list(reader)
+
+    assert metrics == [
+        FakeMetric(name="Nils", counts=Counter({FakeEnum.FOO: 5, FakeEnum.BAR: 0})),
+    ]
+
+
 def test_counter_pivot_table_model_dump_json_mode() -> None:
     """Test that model_dump(mode='json') works with Counter pivot tables."""
 


### PR DESCRIPTION
## Summary

A `Counter[StrEnum]` field constructed without one of the enum members serialized only the *present* members. Since the header always lists every member, `csv.DictWriter` back-filled the absent column with an empty cell, and reading the file back raised a `ValidationError` parsing `""` as an `int`.

The pivot serializer now iterates the enum and emits `0` for any member absent from the `Counter`, so the absent member round-trips.

| `counts` written | Before (on disk) | After |
|---|---|---|
| `Counter({FOO: 1, BAR: 2})` | `1\t2` | unchanged |
| `Counter({FOO: 5})` (BAR absent) | `5\t` → read-back **raises** | `5\t0` → reads back `{FOO: 5, BAR: 0}` |

