### PR TITLE
feat: infer delimiter from file extension in open()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Introduce `MetricReader` for iterating metrics from any text-IO source (#41)
 - Add an `encoding` kwarg on `MetricReader.open` and `MetricWriter.open` (#43)
 - Transparent gzip/bz2/xz support via `xopen` (#44)
+- Infer the delimiter from the file extension in `MetricReader.open`/`MetricWriter.open`; pass `delimiter=` to override (#61)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -117,18 +117,22 @@ Invalid data raises `pydantic.ValidationError` with details about which field fa
 
 ## Core Usage
 
-### Custom Delimiters
+### Delimiters
 
-Both reading and writing support custom delimiters for working with CSV or other formats:
+The field delimiter is inferred from the file extension, so common formats need no configuration: `.csv` is comma-delimited, while `.tsv`, `.txt`, `.tab`, and Picard-style `*metrics` files (e.g. `.insert_size_metrics`) are tab-delimited. A trailing compression suffix (`.gz`, `.bz2`, `.xz`) is ignored, so `data.csv.gz` is still comma-delimited.
 
 ```python
-# Reading CSV files
-with MetricReader.open(MyMetric, "data.csv", delimiter=",") as reader:
+# Comma-delimited, inferred from the .csv extension
+with MetricReader.open(MyMetric, "data.csv") as reader:
     for metric in reader:
         ...
+```
 
-# Writing CSV files
-with MetricWriter.open(MyMetric, "output.csv", delimiter=",") as writer:
+Pass `delimiter=` to override inference, or to read or write a file whose extension isn't recognized. An unrecognized extension with no explicit `delimiter` raises `ValueError`.
+
+```python
+# Pipe-delimited file with an unrecognized extension
+with MetricWriter.open(MyMetric, "output.dat", delimiter="|") as writer:
     ...
 ```
 

--- a/fgmetric/_delimiter.py
+++ b/fgmetric/_delimiter.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+# Suffixes xopen treats as compression and strips for format detection.
+_COMPRESSION_SUFFIXES = frozenset({".gz", ".bz2", ".xz"})
+
+_DELIMITER_BY_SUFFIX: dict[str, str] = {".csv": ",", ".tsv": "\t", ".txt": "\t", ".tab": "\t"}
+
+# Picard-style extensions (e.g. `.insert_size_metrics`) are tab-delimited.
+_METRICS_SUFFIX = "metrics"
+
+
+def infer_delimiter(path: Path | str) -> str:
+    """
+    Infer the field delimiter from a path's file extension.
+
+    A single trailing compression suffix (`.gz`, `.bz2`, `.xz`) is stripped first, mirroring
+    `xopen`'s compression detection, so `.tsv.gz`, `.csv.bz2`, etc. resolve from the underlying
+    data extension. Matching is case-insensitive.
+
+    `.csv` resolves to a comma; `.tsv`, `.txt`, `.tab`, and any extension ending in `metrics`
+    (e.g. Picard-style `.insert_size_metrics`) resolve to a tab.
+
+    Args:
+        path: The file path whose extension determines the delimiter.
+
+    Returns:
+        The single-character field delimiter.
+
+    Raises:
+        ValueError: If the extension is not recognized. Pass `delimiter=` explicitly for such
+            files.
+    """
+    p = Path(path)
+    suffixes = [suffix.lower() for suffix in p.suffixes]
+    if suffixes and suffixes[-1] in _COMPRESSION_SUFFIXES:
+        suffixes.pop()
+    data_suffix = suffixes[-1] if suffixes else ""
+    if data_suffix in _DELIMITER_BY_SUFFIX:
+        return _DELIMITER_BY_SUFFIX[data_suffix]
+    if data_suffix.endswith(_METRICS_SUFFIX):
+        return "\t"
+    recognized = ", ".join(_DELIMITER_BY_SUFFIX)
+    raise ValueError(
+        f"Could not infer a delimiter from path {p.name!r}. Recognized extensions are "
+        f"{recognized}, and any extension ending in 'metrics', optionally followed by a "
+        "compression suffix (.gz, .bz2, .xz). Pass `delimiter=` explicitly for other files."
+    )

--- a/fgmetric/_delimiter.py
+++ b/fgmetric/_delimiter.py
@@ -3,7 +3,12 @@ from pathlib import Path
 # Suffixes xopen treats as compression and strips for format detection.
 _COMPRESSION_SUFFIXES = frozenset({".gz", ".bz2", ".xz"})
 
-_DELIMITER_BY_SUFFIX: dict[str, str] = {".csv": ",", ".tsv": "\t", ".txt": "\t", ".tab": "\t"}
+_DELIMITER_BY_SUFFIX: dict[str, str] = {
+    ".csv": ",",
+    ".tsv": "\t",
+    ".txt": "\t",
+    ".tab": "\t",
+}
 
 # Picard-style extensions (e.g. `.insert_size_metrics`) are tab-delimited.
 _METRICS_SUFFIX = "metrics"
@@ -13,12 +18,13 @@ def infer_delimiter(path: Path | str) -> str:
     """
     Infer the field delimiter from a path's file extension.
 
-    A single trailing compression suffix (`.gz`, `.bz2`, `.xz`) is stripped first, mirroring
-    `xopen`'s compression detection, so `.tsv.gz`, `.csv.bz2`, etc. resolve from the underlying
-    data extension. Matching is case-insensitive.
+    A single trailing compression suffix (`.gz`, `.bz2`, `.xz`) is stripped if present, so
+    `.tsv.gz`, `.csv.bz2`, etc. resolve from the underlying file format extension.
 
     `.csv` resolves to a comma; `.tsv`, `.txt`, `.tab`, and any extension ending in `metrics`
     (e.g. Picard-style `.insert_size_metrics`) resolve to a tab.
+
+    Suffix matching is case-insensitive.
 
     Args:
         path: The file path whose extension determines the delimiter.
@@ -27,21 +33,26 @@ def infer_delimiter(path: Path | str) -> str:
         The single-character field delimiter.
 
     Raises:
-        ValueError: If the extension is not recognized. Pass `delimiter=` explicitly for such
-            files.
+        ValueError: If the extension is not recognized. Pass `delimiter=` explicitly for such files.
     """
     p = Path(path)
-    suffixes = [suffix.lower() for suffix in p.suffixes]
-    if suffixes and suffixes[-1] in _COMPRESSION_SUFFIXES:
-        suffixes.pop()
-    data_suffix = suffixes[-1] if suffixes else ""
-    if data_suffix in _DELIMITER_BY_SUFFIX:
-        return _DELIMITER_BY_SUFFIX[data_suffix]
-    if data_suffix.endswith(_METRICS_SUFFIX):
-        return "\t"
-    recognized = ", ".join(_DELIMITER_BY_SUFFIX)
-    raise ValueError(
-        f"Could not infer a delimiter from path {p.name!r}. Recognized extensions are "
-        f"{recognized}, and any extension ending in 'metrics', optionally followed by a "
-        "compression suffix (.gz, .bz2, .xz). Pass `delimiter=` explicitly for other files."
-    )
+
+    if p.suffix.lower() in _COMPRESSION_SUFFIXES:
+        # strip compression suffix, if it exists
+        p = p.with_suffix("")
+
+    suffix = p.suffix.lower()
+
+    if suffix in _DELIMITER_BY_SUFFIX:
+        delimiter = _DELIMITER_BY_SUFFIX[suffix]
+    elif suffix.endswith(_METRICS_SUFFIX):
+        delimiter = "\t"
+    else:
+        recognized = ", ".join(_DELIMITER_BY_SUFFIX)
+        raise ValueError(
+            f"Could not infer a delimiter from path {p.name!r}. Recognized extensions are "
+            f"{recognized}, and any extension ending in 'metrics', optionally followed by a "
+            "compression suffix (.gz, .bz2, .xz). Pass `delimiter=` explicitly for other files."
+        )
+
+    return delimiter

--- a/fgmetric/metric_reader.py
+++ b/fgmetric/metric_reader.py
@@ -10,6 +10,8 @@ from typing import Self
 
 from xopen import xopen
 
+from fgmetric._delimiter import infer_delimiter
+
 if TYPE_CHECKING:
     from fgmetric.metric import Metric
 
@@ -73,7 +75,7 @@ class MetricReader[T: Metric]:
         cls,
         metric_class: type[T],
         path: Path | str,
-        delimiter: str = "\t",
+        delimiter: str | None = None,
         fieldnames: Sequence[str] | None = None,
         encoding: str = "utf-8-sig",
     ) -> Iterator[Self]:
@@ -93,7 +95,10 @@ class MetricReader[T: Metric]:
         Args:
             metric_class: Metric class.
             path: Filesystem path to the input file.
-            delimiter: The input file delimiter.
+            delimiter: The input file delimiter. When `None` (the default), the delimiter is
+                inferred from the file extension: `.csv` → comma; `.tsv`, `.txt`, `.tab`, or
+                any extension ending in `metrics` → tab — ignoring any trailing compression
+                suffix. Unrecognized extensions raise `ValueError`.
             fieldnames: Optional sequence of field names. If provided, the input is
                 treated as headerless and these names are used as the column
                 headers.
@@ -102,6 +107,10 @@ class MetricReader[T: Metric]:
         Yields:
             A `MetricReader` over the opened file.
 
+        Raises:
+            ValueError: If `delimiter` is omitted and the delimiter cannot be inferred from
+                the file extension.
+
         Example:
             ```python
             with MetricReader.open(AlignmentMetric, "metrics.txt") as reader:
@@ -109,6 +118,8 @@ class MetricReader[T: Metric]:
                     ...
             ```
         """
+        if delimiter is None:
+            delimiter = infer_delimiter(path)
         with xopen(path, mode="rt", encoding=encoding) as handle:
             yield cls(metric_class, handle, delimiter, fieldnames)
 

--- a/fgmetric/metric_writer.py
+++ b/fgmetric/metric_writer.py
@@ -8,6 +8,7 @@ from typing import TextIO
 
 from xopen import xopen
 
+from fgmetric._delimiter import infer_delimiter
 from fgmetric.metric import Metric
 
 
@@ -55,7 +56,7 @@ class MetricWriter[T: Metric]:
         cls,
         metric_class: type[T],
         path: Path | str,
-        delimiter: str = "\t",
+        delimiter: str | None = None,
         lineterminator: str = "\n",
         encoding: str = "utf-8",
     ) -> Iterator[Self]:
@@ -74,12 +75,19 @@ class MetricWriter[T: Metric]:
         Args:
             metric_class: Metric class.
             path: Filesystem path to the output file.
-            delimiter: The output file delimiter.
+            delimiter: The output file delimiter. When `None` (the default), the delimiter is
+                inferred from the file extension: `.csv` → comma; `.tsv`, `.txt`, `.tab`, or
+                any extension ending in `metrics` → tab — ignoring any trailing compression
+                suffix. Unrecognized extensions raise `ValueError`.
             lineterminator: The string used to terminate lines.
             encoding: The text encoding used to write the file.
 
         Yields:
             A `MetricWriter` over the opened file.
+
+        Raises:
+            ValueError: If `delimiter` is omitted and the delimiter cannot be inferred from
+                the file extension.
 
         Example:
             ```python
@@ -87,6 +95,8 @@ class MetricWriter[T: Metric]:
                 writer.writeall(metrics)
             ```
         """
+        if delimiter is None:
+            delimiter = infer_delimiter(path)
         with xopen(path, mode="wt", encoding=encoding) as handle:
             yield cls(metric_class, handle, delimiter, lineterminator)
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -169,6 +169,26 @@ def test_list_with_optional_elements_roundtrip() -> None:
     assert serialized["values"] == "1,,3"
 
 
+def test_list_field_round_trips_through_inferred_csv(tmp_path: Path) -> None:
+    """A list field survives the inferred comma CSV delimiter via CSV quoting."""
+
+    class FakeMetric(Metric):
+        name: str
+        tags: list[str]
+
+    p = tmp_path / "metrics.csv"  # `.csv` infers a comma delimiter
+    metric = FakeMetric(name="alice", tags=["x", "y", "z"])
+    with MetricWriter.open(FakeMetric, p) as writer:
+        writer.write(metric)
+
+    # The list serializes to "x,y,z", whose commas collide with the comma delimiter, so csv
+    # quote-protects the field on disk rather than splitting it into extra columns.
+    assert p.read_text() == 'name,tags\nalice,"x,y,z"\n'
+
+    with MetricReader.open(FakeMetric, p) as reader:
+        assert list(reader) == [metric]
+
+
 def test_counter_pivot_table_of_enum(tmp_path: Path) -> None:
     """Test that we can read and write Counters as pivot tables."""
 

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -50,6 +50,26 @@ def test_round_trip_compressed(tmp_path: Path, ext: str) -> None:
         assert list(reader) == expected
 
 
+@pytest.mark.parametrize("ext", ["", ".gz", ".bz2", ".xz"])
+def test_round_trip_csv_with_inferred_delimiter(tmp_path: Path, ext: str) -> None:
+    """Test that delimiter inference composes with compression suffixes on round trip."""
+    p = tmp_path / f"metrics.csv{ext}"
+    expected = [ExampleMetric(name="alice", value=1), ExampleMetric(name="bob", value=2)]
+    with MetricWriter.open(ExampleMetric, p) as writer:
+        writer.writeall(expected)
+    with MetricReader.open(ExampleMetric, p) as reader:
+        assert list(reader) == expected
+
+
+def test_gzipped_csv_is_comma_delimited(tmp_path: Path) -> None:
+    """A .csv.gz file written without an explicit delimiter is comma-delimited inside."""
+    p = tmp_path / "out.csv.gz"
+    with MetricWriter.open(ExampleMetric, p) as writer:
+        writer.write(ExampleMetric(name="alice", value=1))
+    with gzip.open(p, mode="rt", encoding="utf-8") as f:
+        assert f.read() == "name,value\nalice,1\n"
+
+
 def test_gzipped_file_is_actually_gzipped(tmp_path: Path) -> None:
     """A .gz file written by MetricWriter.open has the gzip magic bytes."""
     p = tmp_path / "out.tsv.gz"

--- a/tests/test_delimiter.py
+++ b/tests/test_delimiter.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pytest
+
+from fgmetric._delimiter import infer_delimiter
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        ("metrics.csv", ","),
+        ("metrics.tsv", "\t"),
+        ("metrics.txt", "\t"),
+        ("metrics.tab", "\t"),
+        ("sample.insert_size_metrics", "\t"),
+        ("metrics.csv.gz", ","),
+        ("metrics.csv.bz2", ","),
+        ("metrics.csv.xz", ","),
+        ("metrics.tsv.gz", "\t"),
+        ("metrics.tsv.bz2", "\t"),
+        ("metrics.tsv.xz", "\t"),
+        ("sample.alignment_summary_metrics.gz", "\t"),
+        ("METRICS.CSV.GZ", ","),
+        ("Metrics.Tsv", "\t"),
+    ],
+)
+def test_infer_delimiter(filename: str, expected: str) -> None:
+    """Test delimiter inference across data extensions and compression suffixes."""
+    assert infer_delimiter(filename) == expected
+    assert infer_delimiter(Path("/some/dir") / filename) == expected
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "metrics.dat",
+        "metrics",
+        "metrics.gz",  # bare compression suffix with no data extension underneath
+        "metrics.gz.gz",  # only a single compression suffix is stripped
+        "metrics.csv.zip",  # unrecognized outer suffix is not treated as compression
+    ],
+)
+def test_infer_delimiter_raises_for_unrecognized_extension(filename: str) -> None:
+    """Test that unrecognized extensions raise instead of silently defaulting."""
+    with pytest.raises(ValueError, match="Could not infer a delimiter"):
+        infer_delimiter(filename)

--- a/tests/test_metric_reader.py
+++ b/tests/test_metric_reader.py
@@ -81,6 +81,36 @@ def test_open_requires_context_manager_usage(tmp_path: Path) -> None:
         list(cm)  # type: ignore[call-overload]
 
 
+def test_open_infers_delimiter_from_extension(tmp_path: Path) -> None:
+    """Test that MetricReader.open reads a .csv file as comma-delimited by default."""
+    p = tmp_path / "metrics.csv"
+    p.write_text("name,value\nalice,1\nbob,2\n")
+    with MetricReader.open(ExampleMetric, p) as reader:
+        metrics = list(reader)
+    assert metrics == [
+        ExampleMetric(name="alice", value=1),
+        ExampleMetric(name="bob", value=2),
+    ]
+
+
+def test_open_explicit_delimiter_overrides_inference(tmp_path: Path) -> None:
+    """Test that an explicit delimiter wins over the extension-inferred one."""
+    p = tmp_path / "metrics.csv"
+    p.write_text("name\tvalue\nalice\t1\n")
+    with MetricReader.open(ExampleMetric, p, delimiter="\t") as reader:
+        metrics = list(reader)
+    assert metrics == [ExampleMetric(name="alice", value=1)]
+
+
+def test_open_raises_for_uninferrable_delimiter(tmp_path: Path) -> None:
+    """Test that an unrecognized extension raises when no delimiter is given."""
+    p = tmp_path / "metrics.dat"
+    p.write_text("name\tvalue\nalice\t1\n")
+    with pytest.raises(ValueError, match="Could not infer a delimiter"):
+        with MetricReader.open(ExampleMetric, p):
+            pass
+
+
 def test_open_respects_encoding(tmp_path: Path) -> None:
     """Test that MetricReader.open decodes the file with the specified encoding."""
     p = tmp_path / "metrics.tsv"

--- a/tests/test_metric_writer.py
+++ b/tests/test_metric_writer.py
@@ -100,6 +100,32 @@ def test_writer_open_does_not_touch_file_until_enter(tmp_path: Path) -> None:
     assert p.read_text() == "existing content\n"
 
 
+def test_writer_open_infers_delimiter_from_extension(tmp_path: Path) -> None:
+    """Test that MetricWriter.open writes a .csv file as comma-delimited by default."""
+    p = tmp_path / "out.csv"
+    with MetricWriter.open(FakeMetric, p) as writer:
+        writer.write(FakeMetric(foo="abc", bar=1))
+    assert p.read_text() == "foo,bar\nabc,1\n"
+
+
+def test_writer_open_explicit_delimiter_overrides_inference(tmp_path: Path) -> None:
+    """Test that an explicit delimiter wins over the extension-inferred one."""
+    p = tmp_path / "out.csv"
+    with MetricWriter.open(FakeMetric, p, delimiter="\t") as writer:
+        writer.write(FakeMetric(foo="abc", bar=1))
+    assert p.read_text() == "foo\tbar\nabc\t1\n"
+
+
+def test_writer_open_raises_for_uninferrable_delimiter(tmp_path: Path) -> None:
+    """Test that an unrecognized extension raises when no delimiter is given."""
+    p = tmp_path / "out.dat"
+    with pytest.raises(ValueError, match="Could not infer a delimiter"):
+        with MetricWriter.open(FakeMetric, p):
+            pass
+    # The file must not be created when inference fails.
+    assert not p.exists()
+
+
 def test_writer_open_respects_encoding(tmp_path: Path) -> None:
     """Test that MetricWriter.open writes with the specified encoding."""
     p = tmp_path / "out.tsv"


### PR DESCRIPTION
## Summary

Fixes #46

Infer delimiter from the file extension. CSVs are inferred to have a comma delimiter, files ending in `.tsv`, `.txt`, `.tab` or a suffix ending with `metrics` are inferred to have a tab delimiter. 

File extensions that aren't explicitly supported must be read or written with an explicit `delimiter` argument. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic delimiter detection from file extensions (CSV, TSV/TXT/TAB, Picard-style metrics) and common compressed variants; explicit delimiter still overrides detection and missing/unknown extensions produce a clear error.

* **Tests**
  * Added comprehensive tests covering inference, overrides, compressed files, error cases, and CSV round-trip for list fields.

* **Documentation**
  * Updated docs and changelog to describe delimiter inference behavior and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->