### PR TITLE
feat: restore Metric.read()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `MetricWriter` is IO-first; open a path with `MetricWriter.open()` rather than passing it to the constructor (#42)
-- `Metric.read` is now a thin wrapper over `MetricReader.open`; it accepts `str` paths in addition to `Path` and gains transparent decompression and the `encoding` kwarg (#62)
+- `Metric.read` is now a thin wrapper over `MetricReader.open` and reads eagerly, returning a `list` instead of a lazy generator; it accepts `str` paths in addition to `Path` and gains transparent decompression and the `encoding` kwarg. Use `MetricReader.open` to stream metrics without holding them all in memory (#62)
 
 ## [0.3.0] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `MetricWriter` is IO-first; open a path with `MetricWriter.open()` rather than passing it to the constructor (#42)
-
-### Removed
-
-- Remove `Metric.read()` — read metrics via `MetricReader.open()` instead (#49)
+- `Metric.read` is now a thin wrapper over `MetricReader.open`; it accepts `str` paths in addition to `Path` and gains transparent decompression and the `encoding` kwarg (#62)
 
 ## [0.3.0] - 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ with MetricWriter.open(AlignmentMetric, "output.tsv") as writer:
     writer.writeall(metrics)
 ```
 
+`Metric.read()` reads the whole file into a list. To stream metrics one at a time without holding them all in memory, use `MetricReader.open()`:
+
+```python
+# Streaming from a path
+with MetricReader.open(AlignmentMetric, "alignments.tsv") as reader:
+    for metric in reader:
+        print(f"{metric.read_name}: MQ={metric.mapping_quality}")
+```
+
 To read from an open file handle or any other text IO source (e.g. `StringIO`), use `MetricReader` directly:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -62,11 +62,10 @@ with open("metrics.tsv") as f:
 `fgmetric` replaces this with:
 
 ```py
-with MetricReader.open(AlignmentMetric, path) as reader:
-    for metric in reader:
-        # metric.mapping_quality is already an int
-        # metric.is_duplicate is already a bool
-        # metric.score is already Optional[float]
+for metric in AlignmentMetric.read(path):
+    # metric.mapping_quality is already an int
+    # metric.is_duplicate is already a bool
+    # metric.score is already Optional[float]
 ```
 
 **How it compares:**
@@ -92,9 +91,8 @@ Then read or write:
 
 ```python
 # Reading
-with MetricReader.open(AlignmentMetric, "alignments.tsv") as reader:
-    for metric in reader:
-        print(f"{metric.read_name}: MQ={metric.mapping_quality}")
+for metric in AlignmentMetric.read("alignments.tsv"):
+    print(f"{metric.read_name}: MQ={metric.mapping_quality}")
 
 # Writing
 metrics = [
@@ -103,6 +101,16 @@ metrics = [
 ]
 with MetricWriter.open(AlignmentMetric, "output.tsv") as writer:
     writer.writeall(metrics)
+```
+
+To read from an open file handle or any other text IO source (e.g. `StringIO`), use `MetricReader` directly:
+
+```python
+# Reading from an IO source
+with open("alignments.tsv") as handle:
+    reader = MetricReader(AlignmentMetric, handle)
+    for metric in reader:
+        print(f"{metric.read_name}: MQ={metric.mapping_quality}")
 ```
 
 Example input file (`alignments.tsv`):
@@ -123,9 +131,8 @@ The field delimiter is inferred from the file extension, so common formats need 
 
 ```python
 # Comma-delimited, inferred from the .csv extension
-with MetricReader.open(MyMetric, "data.csv") as reader:
-    for metric in reader:
-        ...
+for metric in MyMetric.read("data.csv"):
+    ...
 ```
 
 Pass `delimiter=` to override inference, or to read or write a file whose extension isn't recognized. An unrecognized extension with no explicit `delimiter` raises `ValueError`.
@@ -141,9 +148,8 @@ with MetricWriter.open(MyMetric, "output.dat", delimiter="|") as writer:
 Reading and writing transparently handle gzip, bzip2, and xz files based on the path extension (via [xopen](https://github.com/pycompression/xopen)):
 
 ```python
-with MetricReader.open(AlignmentMetric, "alignments.tsv.gz") as reader:
-    for metric in reader:
-        ...
+for metric in AlignmentMetric.read("alignments.tsv.gz"):
+    ...
 
 with MetricWriter.open(AlignmentMetric, "output.tsv.bz2") as writer:
     writer.writeall(metrics)

--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -1,5 +1,9 @@
 from abc import ABC
+from collections.abc import Iterator
+from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
+from typing import Self
 
 from pydantic import BaseModel
 from pydantic import model_validator
@@ -7,6 +11,7 @@ from pydantic import model_validator
 from fgmetric._typing_extensions import is_optional
 from fgmetric.collections import CounterPivotTable
 from fgmetric.collections import DelimitedList
+from fgmetric.metric_reader import MetricReader
 
 
 class Metric(
@@ -40,19 +45,90 @@ class Metric(
 
     Example:
         ```python
-        from fgmetric import MetricReader
-
         class AlignmentMetric(Metric):
             read_name: str
             mapping_quality: int
             is_duplicate: bool = False
 
         # Read metrics from a TSV file
-        with MetricReader.open(AlignmentMetric, "metrics.txt") as reader:
-            for metric in reader:
-                print(metric.read_name, metric.mapping_quality)
+        for metric in AlignmentMetric.read("metrics.txt"):
+            print(metric.read_name, metric.mapping_quality)
         ```
     """
+
+    @classmethod
+    def read(
+        cls,
+        path: Path | str,
+        delimiter: str = "\t",
+        fieldnames: Sequence[str] | None = None,
+        encoding: str = "utf-8-sig",
+    ) -> Iterator[Self]:
+        """
+        Read Metric instances from a file path.
+
+        Thin wrapper around `MetricReader.open()`. This is a lazy generator: the file is opened
+        on first iteration (not when `read()` is called) and closed when the generator is
+        exhausted or closed. To read from an open handle or other text IO source, use
+        `MetricReader` directly.
+
+        Compression is detected automatically from the file extension: `.gz`, `.bz2`, and `.xz`
+        files are transparently decompressed.
+
+        By default, when `fieldnames` is omitted, the first row of the input file is read as
+        the header.
+
+        When `fieldnames` is supplied, the file is assumed to be headerless and every row is
+        read as data. Rows shorter than `fieldnames` produce `None` for the missing fields,
+        which then go through normal model validation (raising `ValidationError` for required
+        fields).
+
+        As a safeguard, if the first row exactly matches `fieldnames` it is treated as a
+        forgotten header and `ValueError` is raised. Passing `fieldnames` is not a way to
+        override an existing header - to map differently-named header columns to model fields,
+        declare Pydantic field aliases on the `Metric` subclass.
+
+        Args:
+            path: Filesystem path to the input file.
+            delimiter: The input file delimiter.
+            fieldnames: Optional sequence of field names. If provided, the input
+                is treated as headerless and these names are used as the column
+                headers.
+            encoding: The text encoding used to decode the file.
+
+        Yields:
+            Instances of the calling Metric subclass, one per data row.
+
+        Raises:
+            ValueError: If `fieldnames` is supplied and the first row appears to be a header
+                that matches it.
+
+        Example:
+            Reading a file that has a header row:
+
+            ```python
+            for m in AlignmentMetric.read(Path("out.tsv")):
+                print(m.read_name, m.mapping_quality)
+            ```
+
+            Reading a headerless file by supplying column names:
+
+            ```python
+            for m in AlignmentMetric.read(
+                Path("out.tsv"),
+                fieldnames=["read_name", "mapping_quality"],
+            ):
+                print(m.read_name, m.mapping_quality)
+            ```
+        """
+        with MetricReader.open(
+            cls,
+            path,
+            delimiter=delimiter,
+            fieldnames=fieldnames,
+            encoding=encoding,
+        ) as reader:
+            yield from reader
 
     # NB: "Before" validators (mode="before") run before field validators such as
     # `DelimitedList._split_lists()`. Empty strings in Optional fields will always be converted to

--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -59,6 +59,7 @@ class Metric(
     def read(
         cls,
         path: Path | str,
+        # NB: these defaults mirror `MetricReader.open()`; keep them in sync.
         delimiter: str = "\t",
         fieldnames: Sequence[str] | None = None,
         encoding: str = "utf-8-sig",
@@ -66,58 +67,43 @@ class Metric(
         """
         Read all Metric instances from a file path.
 
-        Thin wrapper around `MetricReader.open()`. The entire file is read eagerly: it is
-        opened, parsed, and closed before this method returns, so IO and validation errors are
-        raised at the call site. To stream metrics from a large file without holding them all
-        in memory, or to read from an open handle or other text IO source, use `MetricReader`
-        directly.
+        Eager wrapper around `MetricReader.open()`: the file is opened, parsed, and closed
+        before this method returns, collecting every row into a list. Because reading happens
+        up front, IO and validation errors surface here at the call site rather than partway
+        through iteration.
 
-        Compression is detected automatically from the file extension: `.gz`, `.bz2`, and `.xz`
-        files are transparently decompressed.
-
-        By default, when `fieldnames` is omitted, the first row of the input file is read as
-        the header.
-
-        When `fieldnames` is supplied, the file is assumed to be headerless and every row is
-        read as data. Rows shorter than `fieldnames` produce `None` for the missing fields,
-        which then go through normal model validation (raising `ValidationError` for required
-        fields).
-
-        As a safeguard, if the first row exactly matches `fieldnames` it is treated as a
-        forgotten header and `ValueError` is raised. Passing `fieldnames` is not a way to
-        override an existing header - to map differently-named header columns to model fields,
-        declare Pydantic field aliases on the `Metric` subclass.
+        See `MetricReader.open()` for the file-handling behavior shared by both APIs - encoding,
+        automatic decompression of `.gz`/`.bz2`/`.xz` files, and how `fieldnames` selects
+        header vs. headerless parsing. To stream a large file without holding every row in
+        memory, or to read from an already-open handle or other text IO source, use
+        `MetricReader` directly.
 
         Args:
             path: Filesystem path to the input file.
             delimiter: The input file delimiter.
-            fieldnames: Optional sequence of field names. If provided, the input
-                is treated as headerless and these names are used as the column
-                headers.
+            fieldnames: Optional sequence of field names. If provided, the input is treated as
+                headerless and these names are used as the column headers.
             encoding: The text encoding used to decode the file.
 
         Returns:
             A list of instances of the calling Metric subclass, one per data row.
 
         Raises:
-            ValueError: If `fieldnames` is supplied and the first row appears to be a header
-                that matches it.
+            FileNotFoundError: If `path` does not exist.
+            LookupError: If `encoding` is not a known codec.
+            UnicodeDecodeError: If the file's bytes cannot be decoded using `encoding`.
+            ValueError: If `fieldnames` is supplied and the first row matches it (a likely
+                forgotten header).
+            ValidationError: If a row fails `Metric` validation, e.g. a missing required field
+                or a value of the wrong type.
 
         Example:
-            Reading a file that has a header row:
+            `read` is eager and returns a list, so the whole file is available at once:
 
             ```python
-            for m in AlignmentMetric.read(Path("out.tsv")):
-                print(m.read_name, m.mapping_quality)
-            ```
-
-            Reading a headerless file by supplying column names:
-
-            ```python
-            for m in AlignmentMetric.read(
-                Path("out.tsv"),
-                fieldnames=["read_name", "mapping_quality"],
-            ):
+            metrics = AlignmentMetric.read("metrics.txt")
+            print(f"read {len(metrics)} rows")
+            for m in metrics:
                 print(m.read_name, m.mapping_quality)
             ```
         """

--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from collections.abc import Iterator
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -63,14 +62,15 @@ class Metric(
         delimiter: str = "\t",
         fieldnames: Sequence[str] | None = None,
         encoding: str = "utf-8-sig",
-    ) -> Iterator[Self]:
+    ) -> list[Self]:
         """
-        Read Metric instances from a file path.
+        Read all Metric instances from a file path.
 
-        Thin wrapper around `MetricReader.open()`. This is a lazy generator: the file is opened
-        on first iteration (not when `read()` is called) and closed when the generator is
-        exhausted or closed. To read from an open handle or other text IO source, use
-        `MetricReader` directly.
+        Thin wrapper around `MetricReader.open()`. The entire file is read eagerly: it is
+        opened, parsed, and closed before this method returns, so IO and validation errors are
+        raised at the call site. To stream metrics from a large file without holding them all
+        in memory, or to read from an open handle or other text IO source, use `MetricReader`
+        directly.
 
         Compression is detected automatically from the file extension: `.gz`, `.bz2`, and `.xz`
         files are transparently decompressed.
@@ -96,8 +96,8 @@ class Metric(
                 headers.
             encoding: The text encoding used to decode the file.
 
-        Yields:
-            Instances of the calling Metric subclass, one per data row.
+        Returns:
+            A list of instances of the calling Metric subclass, one per data row.
 
         Raises:
             ValueError: If `fieldnames` is supplied and the first row appears to be a header
@@ -128,7 +128,7 @@ class Metric(
             fieldnames=fieldnames,
             encoding=encoding,
         ) as reader:
-            yield from reader
+            return list(reader)
 
     # NB: "Before" validators (mode="before") run before field validators such as
     # `DelimitedList._split_lists()`. Empty strings in Optional fields will always be converted to

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,0 +1,90 @@
+"""
+Tests for the `Metric.read` convenience classmethod.
+
+`Metric.read` is a thin wrapper over `MetricReader.open`; parsing behavior is covered in
+`test_metric_reader.py`. These tests cover only the wrapper contract: delegation of each
+keyword argument, accepted path types, and generator laziness.
+"""
+
+import gzip
+from collections.abc import Iterator
+from pathlib import Path
+from typing import assert_type
+
+import pytest
+
+from fgmetric import Metric
+
+
+class ExampleMetric(Metric):
+    """Example Metric subclass used in Metric.read tests."""
+
+    name: str
+    value: int
+
+
+def test_read_tsv_with_header(tmp_path: Path) -> None:
+    """Test Metric.read parses a headered TSV into validated instances."""
+    p = tmp_path / "metrics.tsv"
+    p.write_text("name\tvalue\nalice\t1\nbob\t2\n")
+    metrics = ExampleMetric.read(p)
+    assert_type(metrics, Iterator[ExampleMetric])
+    assert list(metrics) == [
+        ExampleMetric(name="alice", value=1),
+        ExampleMetric(name="bob", value=2),
+    ]
+
+
+def test_read_accepts_str_path(tmp_path: Path) -> None:
+    """Test Metric.read accepts a str path as well as a Path."""
+    p = tmp_path / "metrics.tsv"
+    p.write_text("name\tvalue\nalice\t1\n")
+    assert list(ExampleMetric.read(str(p))) == [ExampleMetric(name="alice", value=1)]
+
+
+def test_read_delegates_delimiter(tmp_path: Path) -> None:
+    """Test Metric.read passes `delimiter` through to the reader."""
+    p = tmp_path / "metrics.csv"
+    p.write_text("name,value\nalice,1\n")
+    assert list(ExampleMetric.read(p, delimiter=",")) == [ExampleMetric(name="alice", value=1)]
+
+
+def test_read_delegates_fieldnames(tmp_path: Path) -> None:
+    """Test Metric.read passes `fieldnames` through for headerless input."""
+    p = tmp_path / "metrics.tsv"
+    p.write_text("alice\t1\nbob\t2\n")
+    assert list(ExampleMetric.read(p, fieldnames=["name", "value"])) == [
+        ExampleMetric(name="alice", value=1),
+        ExampleMetric(name="bob", value=2),
+    ]
+
+
+def test_read_rejects_fieldnames_matching_header(tmp_path: Path) -> None:
+    """Test Metric.read raises if `fieldnames` is supplied but the file has a matching header."""
+    p = tmp_path / "metrics.tsv"
+    p.write_text("name\tvalue\nalice\t1\n")
+    with pytest.raises(ValueError, match="appears to be a header"):
+        list(ExampleMetric.read(p, fieldnames=["name", "value"]))
+
+
+def test_read_delegates_encoding(tmp_path: Path) -> None:
+    """Test Metric.read passes `encoding` through to the reader."""
+    p = tmp_path / "metrics.tsv"
+    p.write_bytes("name\tvalue\nzoë\t1\n".encode("utf-16"))
+    assert list(ExampleMetric.read(p, encoding="utf-16")) == [ExampleMetric(name="zoë", value=1)]
+
+
+def test_read_gzipped_file(tmp_path: Path) -> None:
+    """Test Metric.read transparently decompresses .gz files."""
+    p = tmp_path / "metrics.tsv.gz"
+    with gzip.open(p, mode="wt", encoding="utf-8") as f:
+        f.write("name\tvalue\nalice\t1\n")
+    assert list(ExampleMetric.read(p)) == [ExampleMetric(name="alice", value=1)]
+
+
+def test_read_is_lazy(tmp_path: Path) -> None:
+    """Test Metric.read does not open the file until first iteration."""
+    missing = tmp_path / "does-not-exist.tsv"
+    metrics = ExampleMetric.read(missing)
+    with pytest.raises(FileNotFoundError):
+        next(metrics)

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -3,11 +3,10 @@ Tests for the `Metric.read` convenience classmethod.
 
 `Metric.read` is a thin wrapper over `MetricReader.open`; parsing behavior is covered in
 `test_metric_reader.py`. These tests cover only the wrapper contract: delegation of each
-keyword argument, accepted path types, and generator laziness.
+keyword argument, accepted path types, and eager evaluation.
 """
 
 import gzip
-from collections.abc import Iterator
 from pathlib import Path
 from typing import assert_type
 
@@ -28,8 +27,8 @@ def test_read_tsv_with_header(tmp_path: Path) -> None:
     p = tmp_path / "metrics.tsv"
     p.write_text("name\tvalue\nalice\t1\nbob\t2\n")
     metrics = ExampleMetric.read(p)
-    assert_type(metrics, Iterator[ExampleMetric])
-    assert list(metrics) == [
+    assert_type(metrics, list[ExampleMetric])
+    assert metrics == [
         ExampleMetric(name="alice", value=1),
         ExampleMetric(name="bob", value=2),
     ]
@@ -39,21 +38,21 @@ def test_read_accepts_str_path(tmp_path: Path) -> None:
     """Test Metric.read accepts a str path as well as a Path."""
     p = tmp_path / "metrics.tsv"
     p.write_text("name\tvalue\nalice\t1\n")
-    assert list(ExampleMetric.read(str(p))) == [ExampleMetric(name="alice", value=1)]
+    assert ExampleMetric.read(str(p)) == [ExampleMetric(name="alice", value=1)]
 
 
 def test_read_delegates_delimiter(tmp_path: Path) -> None:
     """Test Metric.read passes `delimiter` through to the reader."""
     p = tmp_path / "metrics.csv"
     p.write_text("name,value\nalice,1\n")
-    assert list(ExampleMetric.read(p, delimiter=",")) == [ExampleMetric(name="alice", value=1)]
+    assert ExampleMetric.read(p, delimiter=",") == [ExampleMetric(name="alice", value=1)]
 
 
 def test_read_delegates_fieldnames(tmp_path: Path) -> None:
     """Test Metric.read passes `fieldnames` through for headerless input."""
     p = tmp_path / "metrics.tsv"
     p.write_text("alice\t1\nbob\t2\n")
-    assert list(ExampleMetric.read(p, fieldnames=["name", "value"])) == [
+    assert ExampleMetric.read(p, fieldnames=["name", "value"]) == [
         ExampleMetric(name="alice", value=1),
         ExampleMetric(name="bob", value=2),
     ]
@@ -64,14 +63,14 @@ def test_read_rejects_fieldnames_matching_header(tmp_path: Path) -> None:
     p = tmp_path / "metrics.tsv"
     p.write_text("name\tvalue\nalice\t1\n")
     with pytest.raises(ValueError, match="appears to be a header"):
-        list(ExampleMetric.read(p, fieldnames=["name", "value"]))
+        ExampleMetric.read(p, fieldnames=["name", "value"])
 
 
 def test_read_delegates_encoding(tmp_path: Path) -> None:
     """Test Metric.read passes `encoding` through to the reader."""
     p = tmp_path / "metrics.tsv"
     p.write_bytes("name\tvalue\nzoë\t1\n".encode("utf-16"))
-    assert list(ExampleMetric.read(p, encoding="utf-16")) == [ExampleMetric(name="zoë", value=1)]
+    assert ExampleMetric.read(p, encoding="utf-16") == [ExampleMetric(name="zoë", value=1)]
 
 
 def test_read_gzipped_file(tmp_path: Path) -> None:
@@ -79,12 +78,11 @@ def test_read_gzipped_file(tmp_path: Path) -> None:
     p = tmp_path / "metrics.tsv.gz"
     with gzip.open(p, mode="wt", encoding="utf-8") as f:
         f.write("name\tvalue\nalice\t1\n")
-    assert list(ExampleMetric.read(p)) == [ExampleMetric(name="alice", value=1)]
+    assert ExampleMetric.read(p) == [ExampleMetric(name="alice", value=1)]
 
 
-def test_read_is_lazy(tmp_path: Path) -> None:
-    """Test Metric.read does not open the file until first iteration."""
+def test_read_is_eager(tmp_path: Path) -> None:
+    """Test Metric.read opens and reads the file at call time, not on iteration."""
     missing = tmp_path / "does-not-exist.tsv"
-    metrics = ExampleMetric.read(missing)
     with pytest.raises(FileNotFoundError):
-        next(metrics)
+        ExampleMetric.read(missing)


### PR DESCRIPTION
## Summary

I removed `Metric.read()` when adding `MetricReader`, but have been second-guessing this decision and after discussion with Alison today I've decided to add it back. It's a nice convenience method and there is already code in the wild that relies on it - I'm hesitant to introduce a breaking change here.

One notable change - `Metric.read()` now returns `list[MetricT]` instead of `Iterator[MetricT]`. This is deliberate; streaming is still available via `MetricReader.open()` and in many (most?) cases we simply cast the return value of `read()` to list immediately (see the test suite on this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a convenient method for reading delimited metric files that loads the complete file into memory as a list of objects. Supports string and Path inputs, custom delimiters, automatic decompression of compressed files, and encoding customization.

* **Documentation**
  * Updated usage examples and documentation to demonstrate the new reading method as the preferred approach for basic use cases, with separate examples for streaming alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->