### PR TITLE
feat: validate readable/writable paths in reader and writer open()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 - `MetricWriter` is IO-first; open a path with `MetricWriter.open()` rather than passing it to the constructor (#42)
 - `Metric.read` is now a thin wrapper over `MetricReader.open` and reads eagerly, returning a `list` instead of a lazy generator; it accepts `str` paths in addition to `Path` and gains transparent decompression and the `encoding` kwarg. Use `MetricReader.open` to stream metrics without holding them all in memory (#62)
+- `MetricReader.open` and `MetricWriter.open` eagerly validate that the path is readable/writable on context entry (#66)
 
 ## [0.3.0] - 2026-05-12
 

--- a/fgmetric/_paths.py
+++ b/fgmetric/_paths.py
@@ -1,0 +1,71 @@
+import os
+from pathlib import Path
+
+
+def path_read_error(path: Path | str) -> OSError | None:
+    """
+    Return the error that would result from opening `path` for reading.
+
+    A path is readable when it exists, is not a directory, and the current user has read
+    permission. Non-regular files, e.g. FIFOs from process substitution and character devices
+    such as `/dev/stdin`, are readable. A symlink whose target does not exist is reported as a
+    broken symlink rather than a missing file.
+
+    Args:
+        path: Filesystem path to check.
+
+    Returns:
+        None if `path` is readable; otherwise an unraised exception whose type and message
+        describe the problem (`FileNotFoundError`, `IsADirectoryError`, or `PermissionError`).
+    """
+    path = Path(path)
+    if not path.exists():
+        # `exists()` follows symlinks, so a broken symlink reaches this branch even though the
+        # link itself is present; name both ends of the link to point at the actual problem.
+        message = (
+            f"Path is a symlink to a target that does not exist: {path} -> {path.readlink()}"
+            if path.is_symlink()
+            else f"File does not exist: {path}"
+        )
+        return FileNotFoundError(message)
+    if path.is_dir():
+        return IsADirectoryError(f"Path is a directory: {path}")
+    if not os.access(path, os.R_OK):
+        return PermissionError(f"File is not readable: {path}")
+    return None
+
+
+def path_write_error(path: Path | str) -> OSError | None:
+    """
+    Return the error that would result from opening `path` for writing.
+
+    An existing path is writable when it is not a directory and the current user has write
+    permission. A nonexistent path is writable when its parent directory exists and the current
+    user can create files in it (write and traverse permission on the directory). Symlinks are
+    resolved first, so the checks apply where the write would actually land: a symlink to a
+    nonexistent file is writable when the target's parent directory is.
+
+    Args:
+        path: Filesystem path to check.
+
+    Returns:
+        None if `path` is writable; otherwise an unraised exception whose type and message
+        describe the problem (`FileNotFoundError`, `NotADirectoryError`, `IsADirectoryError`,
+        or `PermissionError`).
+    """
+    path = Path(path)
+    # Resolve symlinks before taking the parent: writing through a symlink creates or modifies
+    # the *target*, whose parent directory may differ from the symlink's own.
+    parent = path.resolve().parent
+    if not parent.is_dir():
+        if parent.exists():
+            return NotADirectoryError(f"Parent is not a directory: {parent}")
+        return FileNotFoundError(f"Parent directory does not exist: {parent}")
+    if path.is_dir():
+        return IsADirectoryError(f"Path is a directory: {path}")
+    if path.exists():
+        if not os.access(path, os.W_OK):
+            return PermissionError(f"File is not writable: {path}")
+    elif not os.access(parent, os.W_OK | os.X_OK):
+        return PermissionError(f"Parent directory is not writable: {parent}")
+    return None

--- a/fgmetric/_paths.py
+++ b/fgmetric/_paths.py
@@ -19,6 +19,7 @@ def path_read_error(path: Path | str) -> OSError | None:
         describe the problem (`FileNotFoundError`, `IsADirectoryError`, or `PermissionError`).
     """
     path = Path(path)
+
     if not path.exists():
         # `exists()` follows symlinks, so a broken symlink reaches this branch even though the
         # link itself is present; name both ends of the link to point at the actual problem.
@@ -32,6 +33,7 @@ def path_read_error(path: Path | str) -> OSError | None:
         return IsADirectoryError(f"Path is a directory: {path}")
     if not os.access(path, os.R_OK):
         return PermissionError(f"File is not readable: {path}")
+
     return None
 
 
@@ -54,13 +56,16 @@ def path_write_error(path: Path | str) -> OSError | None:
         or `PermissionError`).
     """
     path = Path(path)
-    # Resolve symlinks before taking the parent: writing through a symlink creates or modifies
-    # the *target*, whose parent directory may differ from the symlink's own.
+
+    # Resolve symlinks before taking the parent
     parent = path.resolve().parent
-    if not parent.is_dir():
-        if parent.exists():
-            return NotADirectoryError(f"Parent is not a directory: {parent}")
+
+    # Parent must be an extant directory
+    if not parent.exists():
         return FileNotFoundError(f"Parent directory does not exist: {parent}")
+    if not parent.is_dir():
+        return NotADirectoryError(f"Parent is not a directory: {parent}")
+
     if path.is_dir():
         return IsADirectoryError(f"Path is a directory: {path}")
     if path.exists():
@@ -68,4 +73,5 @@ def path_write_error(path: Path | str) -> OSError | None:
             return PermissionError(f"File is not writable: {path}")
     elif not os.access(parent, os.W_OK | os.X_OK):
         return PermissionError(f"Parent directory is not writable: {parent}")
+
     return None

--- a/fgmetric/metric_reader.py
+++ b/fgmetric/metric_reader.py
@@ -11,6 +11,7 @@ from typing import Self
 from xopen import xopen
 
 from fgmetric._delimiter import infer_delimiter
+from fgmetric._paths import path_read_error
 
 if TYPE_CHECKING:
     from fgmetric.metric import Metric
@@ -108,6 +109,9 @@ class MetricReader[T: Metric]:
             A `MetricReader` over the opened file.
 
         Raises:
+            FileNotFoundError: If `path` does not exist.
+            IsADirectoryError: If `path` is a directory.
+            PermissionError: If `path` is not readable.
             ValueError: If `delimiter` is omitted and the delimiter cannot be inferred from
                 the file extension.
 
@@ -118,6 +122,8 @@ class MetricReader[T: Metric]:
                     ...
             ```
         """
+        if (error := path_read_error(path)) is not None:
+            raise error
         if delimiter is None:
             delimiter = infer_delimiter(path)
         with xopen(path, mode="rt", encoding=encoding) as handle:

--- a/fgmetric/metric_writer.py
+++ b/fgmetric/metric_writer.py
@@ -9,6 +9,7 @@ from typing import TextIO
 from xopen import xopen
 
 from fgmetric._delimiter import infer_delimiter
+from fgmetric._paths import path_write_error
 from fgmetric.metric import Metric
 
 
@@ -86,6 +87,11 @@ class MetricWriter[T: Metric]:
             A `MetricWriter` over the opened file.
 
         Raises:
+            FileNotFoundError: If the parent directory of `path` does not exist.
+            NotADirectoryError: If the parent of `path` exists but is not a directory.
+            IsADirectoryError: If `path` is a directory.
+            PermissionError: If `path` exists but is not writable, or if `path` cannot be
+                created in its parent directory.
             ValueError: If `delimiter` is omitted and the delimiter cannot be inferred from
                 the file extension.
 
@@ -95,6 +101,8 @@ class MetricWriter[T: Metric]:
                 writer.writeall(metrics)
             ```
         """
+        if (error := path_write_error(path)) is not None:
+            raise error
         if delimiter is None:
             delimiter = infer_delimiter(path)
         with xopen(path, mode="wt", encoding=encoding) as handle:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+from collections.abc import Callable
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def chmod() -> Iterator[Callable[[Path, int], None]]:
+    """
+    Set a path's permission bits for the duration of a test.
+
+    Yields a function with the signature of `Path.chmod`. All paths modified through it are
+    restored to their original modes (in reverse order) at teardown so pytest can clean up
+    `tmp_path`.
+    """
+    changed: list[tuple[Path, int]] = []
+
+    def _chmod(path: Path, mode: int) -> None:
+        changed.append((path, path.stat().st_mode))
+        path.chmod(mode)
+
+    yield _chmod
+
+    for path, mode in reversed(changed):
+        try:
+            path.chmod(mode)
+        except FileNotFoundError:
+            # Path was removed or renamed during the test; nothing to restore.
+            continue

--- a/tests/test_metric_reader.py
+++ b/tests/test_metric_reader.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from io import StringIO
 from pathlib import Path
 from typing import assert_type
@@ -118,6 +119,39 @@ def test_open_respects_encoding(tmp_path: Path) -> None:
     with MetricReader.open(ExampleMetric, p, encoding="latin-1") as reader:
         metrics = list(reader)
     assert metrics == [ExampleMetric(name="rené", value=1)]
+
+
+def test_open_raises_file_not_found_for_missing_file(tmp_path: Path) -> None:
+    """MetricReader.open raises FileNotFoundError when the file does not exist."""
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        with MetricReader.open(ExampleMetric, tmp_path / "missing.tsv"):
+            pass
+
+
+def test_open_raises_file_not_found_for_missing_compressed_file(tmp_path: Path) -> None:
+    """MetricReader.open raises FileNotFoundError for a missing compressed file too."""
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        with MetricReader.open(ExampleMetric, tmp_path / "missing.tsv.gz"):
+            pass
+
+
+def test_open_raises_is_a_directory_for_directory(tmp_path: Path) -> None:
+    """MetricReader.open raises IsADirectoryError when the path is a directory."""
+    with pytest.raises(IsADirectoryError, match="is a directory"):
+        with MetricReader.open(ExampleMetric, tmp_path):
+            pass
+
+
+def test_open_raises_permission_error_for_unreadable_file(
+    tmp_path: Path, chmod: Callable[[Path, int], None]
+) -> None:
+    """MetricReader.open raises PermissionError when the file is not readable."""
+    p = tmp_path / "metrics.tsv"
+    p.write_text("name\tvalue\nalice\t1\n")
+    chmod(p, 0o000)
+    with pytest.raises(PermissionError, match="not readable"):
+        with MetricReader.open(ExampleMetric, p):
+            pass
 
 
 # ======================================================================================

--- a/tests/test_metric_writer.py
+++ b/tests/test_metric_writer.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from collections.abc import Callable
 from enum import StrEnum
 from enum import unique
 from io import StringIO
@@ -200,3 +201,43 @@ def test_writer_open_closes_owned_file_on_exception(tmp_path: Path, mocker: Mock
             writer.write(FakeMetric(foo="abc", bar=1))
             raise RuntimeError("boom")
     assert spy.spy_return.closed
+
+
+def test_writer_open_raises_file_not_found_for_missing_parent(tmp_path: Path) -> None:
+    """MetricWriter.open raises FileNotFoundError when the parent directory does not exist."""
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        with MetricWriter.open(FakeMetric, tmp_path / "missing" / "out.tsv"):
+            pass
+
+
+def test_writer_open_raises_is_a_directory_for_directory(tmp_path: Path) -> None:
+    """MetricWriter.open raises IsADirectoryError when the path is a directory."""
+    with pytest.raises(IsADirectoryError, match="is a directory"):
+        with MetricWriter.open(FakeMetric, tmp_path):
+            pass
+
+
+def test_writer_open_raises_permission_error_for_readonly_file(
+    tmp_path: Path, chmod: Callable[[Path, int], None]
+) -> None:
+    """MetricWriter.open raises PermissionError when the target file is not writable."""
+    p = tmp_path / "out.tsv"
+    p.write_text("locked\n")
+    chmod(p, 0o444)
+    with pytest.raises(PermissionError, match="not writable"):
+        with MetricWriter.open(FakeMetric, p):
+            pass
+    # The check must fire before the file is opened, so the contents are untouched.
+    assert p.read_text() == "locked\n"
+
+
+def test_writer_open_raises_permission_error_for_readonly_parent(
+    tmp_path: Path, chmod: Callable[[Path, int], None]
+) -> None:
+    """MetricWriter.open raises PermissionError when the parent directory is not writable."""
+    d = tmp_path / "readonly"
+    d.mkdir()
+    chmod(d, 0o555)
+    with pytest.raises(PermissionError, match="not writable"):
+        with MetricWriter.open(FakeMetric, d / "out.tsv"):
+            pass

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,161 @@
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+from fgmetric._paths import path_read_error
+from fgmetric._paths import path_write_error
+
+# ======================================================================================
+# path_read_error
+# ======================================================================================
+
+
+def test_path_read_error_returns_none_for_readable_file(tmp_path: Path) -> None:
+    """A regular file with read permission yields no error."""
+    p = tmp_path / "metrics.tsv"
+    p.write_text("name\tvalue\n")
+    assert path_read_error(p) is None
+
+
+def test_path_read_error_accepts_str(tmp_path: Path) -> None:
+    """A path given as a str is accepted."""
+    p = tmp_path / "metrics.tsv"
+    p.write_text("name\tvalue\n")
+    assert path_read_error(str(p)) is None
+
+
+def test_path_read_error_returns_none_for_fifo(tmp_path: Path) -> None:
+    """A non-regular file such as a FIFO (e.g. from process substitution) is readable."""
+    p = tmp_path / "fifo"
+    os.mkfifo(p)
+    assert path_read_error(p) is None
+
+
+def test_path_read_error_for_missing_path(tmp_path: Path) -> None:
+    """A path that does not exist yields FileNotFoundError."""
+    error = path_read_error(tmp_path / "missing.tsv")
+    assert isinstance(error, FileNotFoundError)
+    assert "does not exist" in str(error)
+
+
+def test_path_read_error_for_broken_symlink(tmp_path: Path) -> None:
+    """A symlink to a nonexistent target yields FileNotFoundError naming both ends of the link."""
+    target = tmp_path / "missing.tsv"
+    link = tmp_path / "link.tsv"
+    link.symlink_to(target)
+    error = path_read_error(link)
+    assert isinstance(error, FileNotFoundError)
+    assert "symlink" in str(error)
+    assert str(target) in str(error)
+
+
+def test_path_read_error_for_directory(tmp_path: Path) -> None:
+    """A directory yields IsADirectoryError."""
+    error = path_read_error(tmp_path)
+    assert isinstance(error, IsADirectoryError)
+    assert "is a directory" in str(error)
+
+
+def test_path_read_error_without_read_permission(
+    tmp_path: Path, chmod: Callable[[Path, int], None]
+) -> None:
+    """A file whose read permission bits are unset yields PermissionError."""
+    p = tmp_path / "metrics.tsv"
+    p.write_text("name\tvalue\n")
+    chmod(p, 0o000)
+    error = path_read_error(p)
+    assert isinstance(error, PermissionError)
+    assert "not readable" in str(error)
+
+
+# ======================================================================================
+# path_write_error
+# ======================================================================================
+
+
+def test_path_write_error_returns_none_for_writable_file(tmp_path: Path) -> None:
+    """An existing file with write permission yields no error."""
+    p = tmp_path / "out.tsv"
+    p.write_text("existing\n")
+    assert path_write_error(p) is None
+
+
+def test_path_write_error_accepts_str(tmp_path: Path) -> None:
+    """A path given as a str is accepted."""
+    assert path_write_error(str(tmp_path / "out.tsv")) is None
+
+
+def test_path_write_error_returns_none_for_new_file_in_writable_directory(
+    tmp_path: Path,
+) -> None:
+    """A nonexistent file in a writable directory yields no error."""
+    assert path_write_error(tmp_path / "out.tsv") is None
+
+
+def test_path_write_error_for_missing_parent(tmp_path: Path) -> None:
+    """A nonexistent file in a nonexistent directory yields FileNotFoundError."""
+    error = path_write_error(tmp_path / "missing" / "out.tsv")
+    assert isinstance(error, FileNotFoundError)
+    assert "does not exist" in str(error)
+
+
+def test_path_write_error_for_parent_that_is_a_file(tmp_path: Path) -> None:
+    """A path whose parent exists but is a file yields NotADirectoryError."""
+    p = tmp_path / "afile.txt"
+    p.write_text("x\n")
+    error = path_write_error(p / "out.tsv")
+    assert isinstance(error, NotADirectoryError)
+    assert "not a directory" in str(error)
+
+
+def test_path_write_error_returns_none_for_symlink_to_new_file_in_writable_directory(
+    tmp_path: Path,
+) -> None:
+    """
+    A symlink to a nonexistent file in a writable directory yields no error.
+
+    Opening such a symlink for writing creates the target file.
+    """
+    link = tmp_path / "link.tsv"
+    link.symlink_to(tmp_path / "target.tsv")
+    assert path_write_error(link) is None
+
+
+def test_path_write_error_for_symlink_into_missing_directory(tmp_path: Path) -> None:
+    """A symlink whose target's parent directory does not exist yields FileNotFoundError."""
+    link = tmp_path / "link.tsv"
+    link.symlink_to(tmp_path / "missing" / "target.tsv")
+    error = path_write_error(link)
+    assert isinstance(error, FileNotFoundError)
+    assert "does not exist" in str(error)
+
+
+def test_path_write_error_for_directory(tmp_path: Path) -> None:
+    """A directory yields IsADirectoryError."""
+    error = path_write_error(tmp_path)
+    assert isinstance(error, IsADirectoryError)
+    assert "is a directory" in str(error)
+
+
+def test_path_write_error_for_readonly_file(
+    tmp_path: Path, chmod: Callable[[Path, int], None]
+) -> None:
+    """An existing file without write permission yields PermissionError."""
+    p = tmp_path / "out.tsv"
+    p.write_text("locked\n")
+    chmod(p, 0o444)
+    error = path_write_error(p)
+    assert isinstance(error, PermissionError)
+    assert "not writable" in str(error)
+
+
+def test_path_write_error_for_readonly_parent(
+    tmp_path: Path, chmod: Callable[[Path, int], None]
+) -> None:
+    """A nonexistent file in a read-only directory yields PermissionError."""
+    d = tmp_path / "readonly"
+    d.mkdir()
+    chmod(d, 0o555)
+    error = path_write_error(d / "out.tsv")
+    assert isinstance(error, PermissionError)
+    assert "not writable" in str(error)


### PR DESCRIPTION
## Summary

Fixes #63

`MetricReader.open` and `MetricWriter.open` now check that the provided path is readable/writable before attempting any operations on it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improved Error Handling**
  * Reader and writer now validate file paths up front and raise clearer filesystem errors for missing paths, directory targets, broken symlinks, or permission issues.

* **New Utility**
  * Added reusable path preflight helpers to consistently detect read/write problems before opening files.

* **Tests**
  * Added comprehensive tests covering preflight behavior, symlink edge cases, and permission scenarios for both reading and writing.

* **Documentation**
  * Changelog updated to document the new validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->