### PR TITLE
fix: reject aliased Counter fields at class-definition time

### DIFF
--- a/fgmetric/collections/_counter_pivot_table.py
+++ b/fgmetric/collections/_counter_pivot_table.py
@@ -23,7 +23,9 @@ class CounterPivotTable(BaseModel):
     handled specially.
 
     This mixin permits only *one* field to be annotated as `Counter[T]`, and `T` must be a `StrEnum`
-    type.
+    type. The Counter field may not be Optional, and may not declare an alias: it pivots into one
+    column per enum member, so its field name never appears as a column on disk and there is
+    nothing for an alias to rename.
 
     During validation, fields in the input which match members of the enum type will be collected
     and included in a `Counter` on the validated model. If any members of the enum type are not
@@ -99,6 +101,9 @@ class CounterPivotTable(BaseModel):
         Raises:
             TypeError: If the user-specified model includes more than one field annotated as
                 `Counter[T]`.
+            TypeError: If the Counter field is Optional.
+            TypeError: If the Counter field declares an alias (via `alias`, `validation_alias`, or
+                `serialization_alias`).
 
         Examples:
             >>> # One counter field -> returns its name
@@ -135,6 +140,21 @@ class CounterPivotTable(BaseModel):
             counter_field_info: FieldInfo = cls.model_fields[counter_fieldname]
             if is_optional(counter_field_info.annotation):
                 raise TypeError(f"Optional Counter fields are not supported: '{counter_fieldname}'")
+
+            # A Counter has no single on-disk column: it pivots into one column per enum member, so
+            # its field name never appears in the file. An alias would have nothing to rename, and
+            # under `by_alias=True` it would desync the serializer's lookup key from the dumped
+            # dict (see issue #68). Reject all three alias forms here rather than crash later.
+            if (
+                counter_field_info.alias is not None
+                or counter_field_info.validation_alias is not None
+                or counter_field_info.serialization_alias is not None
+            ):
+                raise TypeError(
+                    f"Aliased Counter fields are not supported: '{counter_fieldname}'. A Counter "
+                    "pivots into one column per enum member, so it has no on-disk column for an "
+                    "alias to rename."
+                )
 
         return counter_fieldname
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Annotated
 
 import pytest
+from pydantic import Field
 from pydantic import PlainSerializer
 
 from fgmetric import Metric
@@ -355,3 +356,47 @@ def test_counter_pivot_table_raises_if_optional_counter() -> None:
             counts: Counter[FakeEnum] | None
 
     assert str(excinfo.value) == "Optional Counter fields are not supported: 'counts'"
+
+
+def test_counter_pivot_table_raises_if_aliased_counter() -> None:
+    """
+    A Counter field may not declare an alias of any kind.
+
+    A Counter pivots into one column per enum member, so its field name never appears as a column
+    on disk. An alias would therefore have nothing to rename, and (under ``by_alias=True``) would
+    desync the serializer's lookup key from the dumped dict. Reject all three alias forms at
+    class-definition time rather than crash later during serialization.
+    """
+
+    @unique
+    class FakeEnum(StrEnum):
+        FOO = "foo"
+
+    expected = (
+        "Aliased Counter fields are not supported: 'counts'. A Counter pivots into one column per "
+        "enum member, so it has no on-disk column for an alias to rename."
+    )
+
+    with pytest.raises(TypeError) as excinfo:
+
+        class AliasMetric(Metric):
+            name: str
+            counts: Counter[FakeEnum] = Field(alias="cts")
+
+    assert str(excinfo.value) == expected
+
+    with pytest.raises(TypeError) as excinfo:
+
+        class ValidationAliasMetric(Metric):
+            name: str
+            counts: Counter[FakeEnum] = Field(validation_alias="cts")
+
+    assert str(excinfo.value) == expected
+
+    with pytest.raises(TypeError) as excinfo:
+
+        class SerializationAliasMetric(Metric):
+            name: str
+            counts: Counter[FakeEnum] = Field(serialization_alias="cts")
+
+    assert str(excinfo.value) == expected


### PR DESCRIPTION
## Summary

Fixes #68

A `Counter` field pivots into one column per enum member, so its field name never appears as a column on disk. 

Declaring a Counter field with an `alias`,
`validation_alias`, or `serialization_alias` now raises `TypeError` at class-definition time, alongside the existing optional/multiple/non-StrEnum Counter guards.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Counter fields with aliases are now properly validated and rejected with a clear error message, preventing unsupported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->