### PR TITLE
feat: refuse to overwrite existing files in MetricWriter.open() by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - `MetricWriter` is IO-first; open a path with `MetricWriter.open()` rather than passing it to the constructor (#42)
 - `Metric.read` is now a thin wrapper over `MetricReader.open` and reads eagerly, returning a `list` instead of a lazy generator; it accepts `str` paths in addition to `Path` and gains transparent decompression and the `encoding` kwarg. Use `MetricReader.open` to stream metrics without holding them all in memory (#62)
 - `MetricReader.open` and `MetricWriter.open` eagerly validate that the path is readable/writable on context entry (#66)
+- `MetricWriter.open` now refuses to overwrite an existing file by default, raising `FileExistsError`; pass `overwrite=True` to truncate and overwrite it (#69)
 
 ## [0.3.0] - 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,20 @@ with MetricWriter.open(AlignmentMetric, "output.tsv.bz2") as writer:
     writer.writeall(metrics)
 ```
 
+### Overwriting existing files
+
+`MetricWriter.open()` refuses to clobber an existing file, raising `FileExistsError`. Pass `overwrite=True` to truncate and overwrite it:
+
+```python
+# Raises FileExistsError if output.tsv already exists
+with MetricWriter.open(AlignmentMetric, "output.tsv") as writer:
+    writer.writeall(metrics)
+
+# Replaces output.tsv if it exists
+with MetricWriter.open(AlignmentMetric, "output.tsv", overwrite=True) as writer:
+    writer.writeall(metrics)
+```
+
 ### List Fields
 
 Fields typed as `list[T]` are automatically parsed from and serialized to delimited strings:

--- a/fgmetric/_paths.py
+++ b/fgmetric/_paths.py
@@ -37,7 +37,7 @@ def path_read_error(path: Path | str) -> OSError | None:
     return None
 
 
-def path_write_error(path: Path | str) -> OSError | None:
+def path_write_error(path: Path | str, overwrite: bool = True) -> OSError | None:
     """
     Return the error that would result from opening `path` for writing.
 
@@ -47,13 +47,20 @@ def path_write_error(path: Path | str) -> OSError | None:
     resolved first, so the checks apply where the write would actually land: a symlink to a
     nonexistent file is writable when the target's parent directory is.
 
+    When `overwrite` is `False`, an existing writable regular file is reported as an error rather
+    than silently clobbered. Only regular files are guarded: directories already report the more
+    specific `IsADirectoryError`, and non-regular files (FIFOs, devices such as `/dev/stdout`)
+    are not destroyed by a write, so they remain writable. A read-only existing file reports
+    `PermissionError` regardless of `overwrite`, since `overwrite=True` could not write it either.
+
     Args:
         path: Filesystem path to check.
+        overwrite: When `False`, refuse to clobber an existing regular file. Defaults to `True`.
 
     Returns:
         None if `path` is writable; otherwise an unraised exception whose type and message
         describe the problem (`FileNotFoundError`, `NotADirectoryError`, `IsADirectoryError`,
-        or `PermissionError`).
+        `PermissionError`, or `FileExistsError`).
     """
     path = Path(path)
 
@@ -71,6 +78,8 @@ def path_write_error(path: Path | str) -> OSError | None:
     if path.exists():
         if not os.access(path, os.W_OK):
             return PermissionError(f"File is not writable: {path}")
+        if not overwrite and path.is_file():
+            return FileExistsError(f"File already exists: {path}")
     elif not os.access(parent, os.W_OK | os.X_OK):
         return PermissionError(f"Parent directory is not writable: {parent}")
 

--- a/fgmetric/_paths.py
+++ b/fgmetric/_paths.py
@@ -37,7 +37,7 @@ def path_read_error(path: Path | str) -> OSError | None:
     return None
 
 
-def path_write_error(path: Path | str, overwrite: bool = True) -> OSError | None:
+def path_write_error(path: Path | str, *, overwrite: bool) -> OSError | None:
     """
     Return the error that would result from opening `path` for writing.
 
@@ -55,7 +55,7 @@ def path_write_error(path: Path | str, overwrite: bool = True) -> OSError | None
 
     Args:
         path: Filesystem path to check.
-        overwrite: When `False`, refuse to clobber an existing regular file. Defaults to `True`.
+        overwrite: When `False`, refuse to clobber an existing regular file.
 
     Returns:
         None if `path` is writable; otherwise an unraised exception whose type and message

--- a/fgmetric/metric_writer.py
+++ b/fgmetric/metric_writer.py
@@ -60,6 +60,7 @@ class MetricWriter[T: Metric]:
         delimiter: str | None = None,
         lineterminator: str = "\n",
         encoding: str = "utf-8",
+        overwrite: bool = False,
     ) -> Iterator[Self]:
         """
         Open `path` for writing and yield a `MetricWriter` over it.
@@ -82,6 +83,8 @@ class MetricWriter[T: Metric]:
                 suffix. Unrecognized extensions raise `ValueError`.
             lineterminator: The string used to terminate lines.
             encoding: The text encoding used to write the file.
+            overwrite: By default, opening an existing file for writing will raise
+                `FileExistsError`. Pass `True` to destructively overwrite an existing file.
 
         Yields:
             A `MetricWriter` over the opened file.
@@ -92,6 +95,7 @@ class MetricWriter[T: Metric]:
             IsADirectoryError: If `path` is a directory.
             PermissionError: If `path` exists but is not writable, or if `path` cannot be
                 created in its parent directory.
+            FileExistsError: If `path` already exists and `overwrite` is `False`.
             ValueError: If `delimiter` is omitted and the delimiter cannot be inferred from
                 the file extension.
 
@@ -101,7 +105,7 @@ class MetricWriter[T: Metric]:
                 writer.writeall(metrics)
             ```
         """
-        if (error := path_write_error(path)) is not None:
+        if (error := path_write_error(path, overwrite=overwrite)) is not None:
             raise error
         if delimiter is None:
             delimiter = infer_delimiter(path)

--- a/tests/test_metric_writer.py
+++ b/tests/test_metric_writer.py
@@ -241,3 +241,23 @@ def test_writer_open_raises_permission_error_for_readonly_parent(
     with pytest.raises(PermissionError, match="not writable"):
         with MetricWriter.open(FakeMetric, d / "out.tsv"):
             pass
+
+
+def test_writer_open_refuses_to_overwrite_existing_file_by_default(tmp_path: Path) -> None:
+    """MetricWriter.open refuses to clobber an existing file unless `overwrite=True`."""
+    p = tmp_path / "out.tsv"
+    p.write_text("existing\n")
+    with pytest.raises(FileExistsError, match="already exists"):
+        with MetricWriter.open(FakeMetric, p):
+            pass
+    # The refusal must fire before the file is opened, so the contents are untouched.
+    assert p.read_text() == "existing\n"
+
+
+def test_writer_open_overwrites_existing_file_when_overwrite_true(tmp_path: Path) -> None:
+    """With `overwrite=True`, MetricWriter.open truncates and rewrites an existing file."""
+    p = tmp_path / "out.tsv"
+    p.write_text("stale\tcontent\nto be replaced\n")
+    with MetricWriter.open(FakeMetric, p, overwrite=True) as writer:
+        writer.write(FakeMetric(foo="abc", bar=1))
+    assert p.read_text() == "foo\tbar\nabc\t1\n"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -159,3 +159,62 @@ def test_path_write_error_for_readonly_parent(
     error = path_write_error(d / "out.tsv")
     assert isinstance(error, PermissionError)
     assert "not writable" in str(error)
+
+
+def test_path_write_error_overwrite_false_for_existing_file(tmp_path: Path) -> None:
+    """With `overwrite=False`, an existing regular file yields FileExistsError."""
+    p = tmp_path / "out.tsv"
+    p.write_text("existing\n")
+    error = path_write_error(p, overwrite=False)
+    assert isinstance(error, FileExistsError)
+    assert "already exists" in str(error)
+
+
+def test_path_write_error_overwrite_false_allows_new_file(tmp_path: Path) -> None:
+    """With `overwrite=False`, a nonexistent file in a writable directory yields no error."""
+    assert path_write_error(tmp_path / "out.tsv", overwrite=False) is None
+
+
+def test_path_write_error_overwrite_false_for_symlink_to_existing_file(tmp_path: Path) -> None:
+    """With `overwrite=False`, a symlink resolving to an existing file yields FileExistsError."""
+    target = tmp_path / "target.tsv"
+    target.write_text("existing\n")
+    link = tmp_path / "link.tsv"
+    link.symlink_to(target)
+    error = path_write_error(link, overwrite=False)
+    assert isinstance(error, FileExistsError)
+    assert "already exists" in str(error)
+
+
+def test_path_write_error_overwrite_false_allows_broken_symlink(tmp_path: Path) -> None:
+    """With `overwrite=False`, a symlink to a nonexistent target is not a clobber and is allowed."""
+    link = tmp_path / "link.tsv"
+    link.symlink_to(tmp_path / "target.tsv")
+    # Writing through the link creates the target, so there is nothing to overwrite.
+    assert path_write_error(link, overwrite=False) is None
+
+
+def test_path_write_error_overwrite_false_allows_fifo(tmp_path: Path) -> None:
+    """With `overwrite=False`, a non-regular file such as a FIFO is not a clobber and is allowed."""
+    p = tmp_path / "fifo"
+    os.mkfifo(p)
+    assert path_write_error(p, overwrite=False) is None
+
+
+def test_path_write_error_overwrite_false_for_directory(tmp_path: Path) -> None:
+    """With `overwrite=False`, a directory still yields the more specific IsADirectoryError."""
+    error = path_write_error(tmp_path, overwrite=False)
+    assert isinstance(error, IsADirectoryError)
+    assert "is a directory" in str(error)
+
+
+def test_path_write_error_overwrite_false_for_readonly_file(
+    tmp_path: Path, chmod: Callable[[Path, int], None]
+) -> None:
+    """With `overwrite=False`, a read-only existing file still yields PermissionError first."""
+    p = tmp_path / "out.tsv"
+    p.write_text("locked\n")
+    chmod(p, 0o444)
+    error = path_write_error(p, overwrite=False)
+    assert isinstance(error, PermissionError)
+    assert "not writable" in str(error)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -2,6 +2,8 @@ import os
 from collections.abc import Callable
 from pathlib import Path
 
+import pytest
+
 from fgmetric._paths import path_read_error
 from fgmetric._paths import path_write_error
 
@@ -73,28 +75,28 @@ def test_path_read_error_without_read_permission(
 # ======================================================================================
 
 
-def test_path_write_error_returns_none_for_writable_file(tmp_path: Path) -> None:
-    """An existing file with write permission yields no error."""
+def test_path_write_error_overwrite_true_for_existing_file(tmp_path: Path) -> None:
+    """With `overwrite=True`, an existing writable file yields no error."""
     p = tmp_path / "out.tsv"
     p.write_text("existing\n")
-    assert path_write_error(p) is None
+    assert path_write_error(p, overwrite=True) is None
 
 
 def test_path_write_error_accepts_str(tmp_path: Path) -> None:
     """A path given as a str is accepted."""
-    assert path_write_error(str(tmp_path / "out.tsv")) is None
+    assert path_write_error(str(tmp_path / "out.tsv"), overwrite=False) is None
 
 
 def test_path_write_error_returns_none_for_new_file_in_writable_directory(
     tmp_path: Path,
 ) -> None:
     """A nonexistent file in a writable directory yields no error."""
-    assert path_write_error(tmp_path / "out.tsv") is None
+    assert path_write_error(tmp_path / "out.tsv", overwrite=False) is None
 
 
 def test_path_write_error_for_missing_parent(tmp_path: Path) -> None:
     """A nonexistent file in a nonexistent directory yields FileNotFoundError."""
-    error = path_write_error(tmp_path / "missing" / "out.tsv")
+    error = path_write_error(tmp_path / "missing" / "out.tsv", overwrite=False)
     assert isinstance(error, FileNotFoundError)
     assert "does not exist" in str(error)
 
@@ -103,7 +105,7 @@ def test_path_write_error_for_parent_that_is_a_file(tmp_path: Path) -> None:
     """A path whose parent exists but is a file yields NotADirectoryError."""
     p = tmp_path / "afile.txt"
     p.write_text("x\n")
-    error = path_write_error(p / "out.tsv")
+    error = path_write_error(p / "out.tsv", overwrite=False)
     assert isinstance(error, NotADirectoryError)
     assert "not a directory" in str(error)
 
@@ -118,35 +120,16 @@ def test_path_write_error_returns_none_for_symlink_to_new_file_in_writable_direc
     """
     link = tmp_path / "link.tsv"
     link.symlink_to(tmp_path / "target.tsv")
-    assert path_write_error(link) is None
+    assert path_write_error(link, overwrite=False) is None
 
 
 def test_path_write_error_for_symlink_into_missing_directory(tmp_path: Path) -> None:
     """A symlink whose target's parent directory does not exist yields FileNotFoundError."""
     link = tmp_path / "link.tsv"
     link.symlink_to(tmp_path / "missing" / "target.tsv")
-    error = path_write_error(link)
+    error = path_write_error(link, overwrite=False)
     assert isinstance(error, FileNotFoundError)
     assert "does not exist" in str(error)
-
-
-def test_path_write_error_for_directory(tmp_path: Path) -> None:
-    """A directory yields IsADirectoryError."""
-    error = path_write_error(tmp_path)
-    assert isinstance(error, IsADirectoryError)
-    assert "is a directory" in str(error)
-
-
-def test_path_write_error_for_readonly_file(
-    tmp_path: Path, chmod: Callable[[Path, int], None]
-) -> None:
-    """An existing file without write permission yields PermissionError."""
-    p = tmp_path / "out.tsv"
-    p.write_text("locked\n")
-    chmod(p, 0o444)
-    error = path_write_error(p)
-    assert isinstance(error, PermissionError)
-    assert "not writable" in str(error)
 
 
 def test_path_write_error_for_readonly_parent(
@@ -156,7 +139,7 @@ def test_path_write_error_for_readonly_parent(
     d = tmp_path / "readonly"
     d.mkdir()
     chmod(d, 0o555)
-    error = path_write_error(d / "out.tsv")
+    error = path_write_error(d / "out.tsv", overwrite=False)
     assert isinstance(error, PermissionError)
     assert "not writable" in str(error)
 
@@ -170,11 +153,6 @@ def test_path_write_error_overwrite_false_for_existing_file(tmp_path: Path) -> N
     assert "already exists" in str(error)
 
 
-def test_path_write_error_overwrite_false_allows_new_file(tmp_path: Path) -> None:
-    """With `overwrite=False`, a nonexistent file in a writable directory yields no error."""
-    assert path_write_error(tmp_path / "out.tsv", overwrite=False) is None
-
-
 def test_path_write_error_overwrite_false_for_symlink_to_existing_file(tmp_path: Path) -> None:
     """With `overwrite=False`, a symlink resolving to an existing file yields FileExistsError."""
     target = tmp_path / "target.tsv"
@@ -186,14 +164,6 @@ def test_path_write_error_overwrite_false_for_symlink_to_existing_file(tmp_path:
     assert "already exists" in str(error)
 
 
-def test_path_write_error_overwrite_false_allows_broken_symlink(tmp_path: Path) -> None:
-    """With `overwrite=False`, a symlink to a nonexistent target is not a clobber and is allowed."""
-    link = tmp_path / "link.tsv"
-    link.symlink_to(tmp_path / "target.tsv")
-    # Writing through the link creates the target, so there is nothing to overwrite.
-    assert path_write_error(link, overwrite=False) is None
-
-
 def test_path_write_error_overwrite_false_allows_fifo(tmp_path: Path) -> None:
     """With `overwrite=False`, a non-regular file such as a FIFO is not a clobber and is allowed."""
     p = tmp_path / "fifo"
@@ -201,20 +171,22 @@ def test_path_write_error_overwrite_false_allows_fifo(tmp_path: Path) -> None:
     assert path_write_error(p, overwrite=False) is None
 
 
-def test_path_write_error_overwrite_false_for_directory(tmp_path: Path) -> None:
-    """With `overwrite=False`, a directory still yields the more specific IsADirectoryError."""
-    error = path_write_error(tmp_path, overwrite=False)
+@pytest.mark.parametrize("overwrite", [True, False])
+def test_path_write_error_directory_beats_overwrite(tmp_path: Path, overwrite: bool) -> None:
+    """A directory yields the more specific IsADirectoryError regardless of `overwrite`."""
+    error = path_write_error(tmp_path, overwrite=overwrite)
     assert isinstance(error, IsADirectoryError)
     assert "is a directory" in str(error)
 
 
-def test_path_write_error_overwrite_false_for_readonly_file(
-    tmp_path: Path, chmod: Callable[[Path, int], None]
+@pytest.mark.parametrize("overwrite", [True, False])
+def test_path_write_error_readonly_file_beats_overwrite(
+    tmp_path: Path, chmod: Callable[[Path, int], None], overwrite: bool
 ) -> None:
-    """With `overwrite=False`, a read-only existing file still yields PermissionError first."""
+    """A read-only existing file yields PermissionError first, regardless of `overwrite`."""
     p = tmp_path / "out.tsv"
     p.write_text("locked\n")
     chmod(p, 0o444)
-    error = path_write_error(p, overwrite=False)
+    error = path_write_error(p, overwrite=overwrite)
     assert isinstance(error, PermissionError)
     assert "not writable" in str(error)


### PR DESCRIPTION
## Summary

Fixes #69

Added an `overwrite: bool = False` flag to `MetricWriter.open()`.

Previously, existing files were silently overwritten. By default, attempting to open an existing file for writing raises an error, and the user can opt into a destructive overwrite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Output file writes now reject overwriting existing files by default.

* **New Features**
  * Added option to allow overwriting existing output files when explicitly enabled.

* **Documentation**
  * Updated documentation and changelog with examples for handling existing output files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->