### PR TITLE
feat: add is_mapping typing helper

### DIFF
--- a/fgmetric/_typing_extensions.py
+++ b/fgmetric/_typing_extensions.py
@@ -205,6 +205,27 @@ def is_collection(annotation: TypeAnnotation | None) -> bool:
     return any(has_origin(annotation, origin) for origin in (list, set, frozenset, tuple))
 
 
+def is_mapping(annotation: TypeAnnotation | None) -> bool:
+    """
+    Check if a type annotation is a `dict` type.
+
+    Matches parameterized `dict[K, V]`, including its optional form. `Counter` is a `dict`
+    subclass but has a distinct origin, so it is not a mapping for this purpose (it is handled
+    separately, see `is_counter`).
+
+    Examples:
+        >>> is_mapping(dict[str, int])
+        True
+        >>> is_mapping(dict[str, int] | None)
+        True
+        >>> is_mapping(Counter[str])
+        False
+        >>> is_mapping(dict)  # bare dict, no type parameters
+        False
+    """
+    return has_origin(annotation, dict)
+
+
 def is_counter(annotation: TypeAnnotation | None) -> bool:
     """
     True if the type annotation is a Counter.

--- a/tests/test_typing_extensions.py
+++ b/tests/test_typing_extensions.py
@@ -9,6 +9,7 @@ from fgmetric._typing_extensions import has_optional_elements
 from fgmetric._typing_extensions import has_origin
 from fgmetric._typing_extensions import is_collection
 from fgmetric._typing_extensions import is_list
+from fgmetric._typing_extensions import is_mapping
 from fgmetric._typing_extensions import is_optional
 from fgmetric._typing_extensions import unpack_optional
 
@@ -109,6 +110,35 @@ def test_is_collection(annotation: TypeAnnotation) -> None:
 def test_is_not_collection(annotation: TypeAnnotation) -> None:
     """Should reject mappings, bare collections, and non-collection types."""
     assert not is_collection(annotation)
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        dict[str, int],
+        dict[int, float],
+        Optional[dict[str, int]],
+        dict[str, int] | None,
+    ],
+)
+def test_is_mapping(annotation: TypeAnnotation) -> None:
+    """Should identify dict types, even within an Optional."""
+    assert is_mapping(annotation)
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        str,
+        list[int],
+        set[str],
+        Counter[str],
+        dict,
+    ],
+)
+def test_is_not_mapping(annotation: TypeAnnotation) -> None:
+    """Should reject Counters, bare dict, and non-dict types."""
+    assert not is_mapping(annotation)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This PR is the fourth in a stack to expand `Metric`'s collection parsing behavior to support `tuple`, `set`, and `dict` along with the existing `list` support, to provide parity with fgpyo.

This PR simply adds a small `is_mapping` helper that identified `dict[K, V]` types. It's added in its own PR to make the ensuing PR (which adds `DelimitedMapping`) easier to review.

## Related Stack

- #80 
- #81 
- #82 
- #83
- #84
