### PR TITLE
feat: add DelimitedMapping converter for dict fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ All notable changes to this project will be documented in this file.
 - Add an `encoding` kwarg on `MetricReader.open` and `MetricWriter.open` (#43)
 - Transparent gzip/bz2/xz support via `xopen` (#44)
 - Infer the delimiter from the file extension in `MetricReader.open`/`MetricWriter.open`; pass `delimiter=` to override (#61)
+- `DelimitedMapping` converter for `dict[K, V]` fields, serialized as delimited `key=value` pairs; the key/value delimiter is configurable via `key_value_delimiter` (#76)
 
 ### Changed
 
 - `MetricWriter` is IO-first; open a path with `MetricWriter.open()` rather than passing it to the constructor (#42)
+- Generalize the `DelimitedList` converter to `DelimitedCollection`, which now also handles `set`, `frozenset`, and `tuple` (including heterogeneous tuples such as `tuple[int, str]`) in addition to `list`. Set and frozenset output is sorted by serialized form for stable roundtrips (#76)
 - `Metric.read` is now a thin wrapper over `MetricReader.open` and reads eagerly, returning a `list` instead of a lazy generator; it accepts `str` paths in addition to `Path` and gains transparent decompression and the `encoding` kwarg. Use `MetricReader.open` to stream metrics without holding them all in memory (#62)
 - `MetricReader.open` and `MetricWriter.open` eagerly validate that the path is readable/writable on context entry (#66)
-- Generalize the `DelimitedList` converter to `DelimitedCollection`, which now also handles `set`, `frozenset`, and `tuple` (including heterogeneous tuples such as `tuple[int, str]`) in addition to `list`. Set and frozenset output is sorted by serialized form for stable roundtrips (#76)
 
 ## [0.3.0] - 2026-05-12
 

--- a/fgmetric/converters/__init__.py
+++ b/fgmetric/converters/__init__.py
@@ -1,9 +1,11 @@
 from fgmetric.converters._counter_pivot_table import CounterPivotTable
 from fgmetric.converters._delimited_collection import DelimitedCollection
+from fgmetric.converters._delimited_mapping import DelimitedMapping
 from fgmetric.converters._null_sentinels import NullSentinels
 
 __all__ = [
     "CounterPivotTable",
     "DelimitedCollection",
+    "DelimitedMapping",
     "NullSentinels",
 ]

--- a/fgmetric/converters/_delimited.py
+++ b/fgmetric/converters/_delimited.py
@@ -12,6 +12,7 @@ from pydantic import field_serializer
 from pydantic import field_validator
 
 from fgmetric._typing_extensions import is_collection
+from fgmetric._typing_extensions import is_mapping
 from fgmetric._typing_extensions import is_optional
 from fgmetric._typing_extensions import unpack_optional
 
@@ -24,53 +25,87 @@ class _DelimitedConverter(BaseModel):
 
     This non-exported base holds the `collection_delimiter` class variable, the single
     field-classification scan run in `__pydantic_init_subclass__`, and the single field validator
-    and field serializer that the public delimited-converter mixins (currently
-    `DelimitedCollection`) build on.
+    and field serializer shared by `DelimitedCollection` and `DelimitedMapping`.
 
-    The validator and serializer live here, rather than on the mixins, because Pydantic permits
-    only *one* serializer per field: two mixins each declaring `field_serializer("*")` would
-    collide, with only the first in the MRO taking effect. A single dispatcher on the shared base
-    sidesteps that.
+    The validator and serializer live here, rather than on the individual mixins, because Pydantic
+    permits only *one* serializer per field: two mixins each declaring `field_serializer("*")`
+    would collide, with only the first in the MRO taking effect. A single dispatcher on the shared
+    base sidesteps that. The dispatcher is gated by the `_handles_collections` and
+    `_handles_mappings` flags, which each mixin flips on. Because the flags resolve through the
+    concrete model's MRO, mixing in `DelimitedCollection` alone enables only collection handling,
+    `DelimitedMapping` alone enables only mapping handling, and mixing in both enables both — which
+    preserves the granular, per-type opt-in.
+
+    The `key_value_delimiter` class variable is declared (without a default) for the benefit of the
+    shared serializer's mapping branch; `DelimitedMapping` supplies the default. It is never read
+    unless `_handles_mappings` is set, so collection-only models need not define it.
     """
 
     collection_delimiter: ClassVar[str] = ","
+    key_value_delimiter: ClassVar[str]
+
+    # Opt-in flags, flipped on by the respective mixin and resolved through the model's MRO.
+    _handles_collections: ClassVar[bool] = False
+    _handles_mappings: ClassVar[bool] = False
+
+    # Field classifications, populated by the shared `__pydantic_init_subclass__` scan.
     _collection_fieldnames: ClassVar[set[str]]
+    _mapping_fieldnames: ClassVar[set[str]]
     _uniform_optional_element_fieldnames: ClassVar[set[str]]
     _tuple_optional_positions: ClassVar[dict[str, tuple[bool, ...]]]
+    _mapping_optional_value_fieldnames: ClassVar[set[str]]
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
         """
-        Validate the collection delimiter and classify the model's fields.
+        Validate the configured delimiters and classify the model's fields.
 
-        1. The collection delimiter must be a single character.
-        2. Each `list`/`set`/`frozenset`/`tuple` field is recorded, along with the
-           per-element/per-position optionality needed to map empty cells to `None`.
+        1. The configured delimiters must each be a single character (and, when mapping handling
+           is enabled, must differ from each other).
+        2. Each field is classified as a delimited collection, a delimited mapping, or neither,
+           recording the per-element/per-value optionality needed to map empty cells to `None`.
         """
         super().__pydantic_init_subclass__(**kwargs)
 
-        cls._require_single_character_collection_delimiter()
+        cls._require_single_character_delimiters()
         cls._classify_fields()
 
     @classmethod
-    def _require_single_character_collection_delimiter(cls) -> None:
-        """Require collection delimiters to be single characters."""
+    def _require_single_character_delimiters(cls) -> None:
+        """Require the configured delimiters to be single, distinct characters."""
         if len(cls.collection_delimiter) != 1:
             raise ValueError(
                 "collection_delimiter must be a single character,"
                 f" got: {cls.collection_delimiter!r}"
             )
 
+        if cls._handles_mappings:
+            if len(cls.key_value_delimiter) != 1:
+                raise ValueError(
+                    "key_value_delimiter must be a single character,"
+                    f" got: {cls.key_value_delimiter!r}"
+                )
+            if cls.key_value_delimiter == cls.collection_delimiter:
+                raise ValueError(
+                    "key_value_delimiter and collection_delimiter must differ,"
+                    f" both are: {cls.collection_delimiter!r}"
+                )
+
     @classmethod
     def _classify_fields(cls) -> None:
         """Scan the model's fields once, recording each field's delimited-converter behavior."""
         cls._collection_fieldnames = set()
+        cls._mapping_fieldnames = set()
         cls._uniform_optional_element_fieldnames = set()
         cls._tuple_optional_positions = {}
+        cls._mapping_optional_value_fieldnames = set()
 
         for name, info in cls.model_fields.items():
-            if is_collection(info.annotation):
-                cls._classify_collection_field(name, info.annotation)
+            annotation = info.annotation
+            if is_mapping(annotation):
+                cls._classify_mapping_field(name, annotation)
+            elif is_collection(annotation):
+                cls._classify_collection_field(name, annotation)
 
     @classmethod
     def _classify_collection_field(cls, name: str, annotation: Any) -> None:
@@ -90,6 +125,16 @@ class _DelimitedConverter(BaseModel):
         elif args and is_optional(args[0]):
             cls._uniform_optional_element_fieldnames.add(name)
 
+    @classmethod
+    def _classify_mapping_field(cls, name: str, annotation: Any) -> None:
+        """Record a `dict[K, V]` field and whether its value type is optional."""
+        cls._mapping_fieldnames.add(name)
+
+        inner = _strip_optional(annotation)
+        args = get_args(inner)
+        if len(args) == 2 and is_optional(args[1]):
+            cls._mapping_optional_value_fieldnames.add(name)
+
     @final
     @field_validator("*", mode="before")
     @classmethod
@@ -99,14 +144,16 @@ class _DelimitedConverter(BaseModel):
             return value
 
         name = info.field_name
-        if name in cls._collection_fieldnames:
+        if cls._handles_collections and name in cls._collection_fieldnames:
             return cls._split_collection(value, name)
+        if cls._handles_mappings and name in cls._mapping_fieldnames:
+            return cls._split_mapping(value, name)
 
         return value
 
     @final
     @classmethod
-    def _split_collection(cls, value: str, name: str | None) -> list[Any]:
+    def _split_collection(cls, value: str, name: str) -> list[Any]:
         """Split a collection cell into a flat list of (string-or-`None`) elements."""
         if not value:
             return []
@@ -126,6 +173,28 @@ class _DelimitedConverter(BaseModel):
         return elements
 
     @final
+    @classmethod
+    def _split_mapping(cls, value: str, name: str) -> dict[Any, Any]:
+        """Split a mapping cell into a dict of (string-or-`None`) keys and values."""
+        if not value:
+            return {}
+
+        result: dict[Any, Any] = {}
+        for pair in value.split(cls.collection_delimiter):
+            if cls.key_value_delimiter not in pair:
+                raise ValueError(
+                    f"Expected a {cls.key_value_delimiter!r}-delimited key/value pair,"
+                    f" got: {pair!r}"
+                )
+            key, item = pair.split(cls.key_value_delimiter, 1)
+            if item == "" and name in cls._mapping_optional_value_fieldnames:
+                result[key] = None
+            else:
+                result[key] = item
+
+        return result
+
+    @final
     @field_serializer("*", mode="wrap")
     def _join_delimited(
         self,
@@ -133,10 +202,16 @@ class _DelimitedConverter(BaseModel):
         nxt: SerializerFunctionWrapHandler,
         info: FieldSerializationInfo,
     ) -> Any:
-        """Join a delimited collection field back into a single delimited string."""
+        """Join a delimited collection/mapping field back into a single delimited string."""
         name = info.field_name
-        if name in self._collection_fieldnames and isinstance(value, (list, set, frozenset, tuple)):
+        if (
+            self._handles_collections
+            and name in self._collection_fieldnames
+            and isinstance(value, (list, set, frozenset, tuple))
+        ):
             return self._join_collection(value, nxt)
+        if self._handles_mappings and name in self._mapping_fieldnames and isinstance(value, dict):
+            return self._join_mapping(value, nxt)
 
         return nxt(value)
 
@@ -158,6 +233,20 @@ class _DelimitedConverter(BaseModel):
             elements.sort()
 
         return self.collection_delimiter.join(elements)
+
+    @final
+    def _join_mapping(self, value: Any, nxt: SerializerFunctionWrapHandler) -> Any:
+        """Serialize each key and value, then join into a delimited string of pairs."""
+        serialized = nxt(value)
+        if not isinstance(serialized, dict):
+            # If the handler already produced something else (unlikely), return it as-is.
+            return serialized
+
+        pairs = [
+            f"{'' if key is None else key}{self.key_value_delimiter}{'' if item is None else item}"
+            for key, item in serialized.items()
+        ]
+        return self.collection_delimiter.join(pairs)
 
 
 def _strip_optional(annotation: Any) -> Any:

--- a/fgmetric/converters/_delimited_collection.py
+++ b/fgmetric/converters/_delimited_collection.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from fgmetric.converters._delimited import _DelimitedConverter
 
 
@@ -93,3 +95,5 @@ class DelimitedCollection(_DelimitedConverter):
         MyMetric(tags=[1, None, 3]).model_dump()  # -> {"tags": "1,,3"}
         ```
     """
+
+    _handles_collections: ClassVar[bool] = True

--- a/fgmetric/converters/_delimited_mapping.py
+++ b/fgmetric/converters/_delimited_mapping.py
@@ -1,0 +1,67 @@
+from typing import ClassVar
+
+from fgmetric.converters._delimited import _DelimitedConverter
+
+
+class DelimitedMapping(_DelimitedConverter):
+    """
+    Serialize and deserialize delimited mappings of (de)serializable types.
+
+    When this mixin is added to `Metric`, fields annotated as `dict[K, V]` will be read and written
+    as delimited strings of key/value pairs. During validation, the string is split into pairs on
+    `collection_delimiter`, each pair is split into a key and value on `key_value_delimiter`, and
+    the keys and values are validated as instances of `K` and `V`. During serialization, the keys
+    and values are serialized to string and joined back into the same shape.
+
+    The key and value types may be any serializable type. The field may be annotated as
+    `dict[K, V]` or `dict[K, V] | None`; as with any primitive type, `None` is validated from and
+    serialized to the empty string. A `dict[K, V | None]` additionally maps an empty value to
+    `None`.
+
+    The pair delimiter is shared with `DelimitedCollection` via the `collection_delimiter` class
+    variable (default `","`); the key/value delimiter is configured separately via the
+    `key_value_delimiter` class variable (default `"="`). The two must be distinct single
+    characters.
+
+    Note:
+        Only the first occurrence of `key_value_delimiter` splits each pair, so values may contain
+        it (e.g. with the default delimiters, `"url=http://a=b"` parses to `{"url": "http://a=b"}`).
+
+    Note:
+        `Counter` is a `dict` subclass but is handled by `CounterPivotTable`, not this mixin.
+
+    Note:
+        Roundtrips are lossy if keys or values contain a delimiter character. Mappings are also
+        flat: nested mappings (e.g. `dict[str, list[int]]`) are not supported, because a flat
+        delimited string cannot be unambiguously re-nested.
+
+    Examples:
+        Basic usage — comma pair delimiter and `=` key/value delimiter (defaults):
+
+        ```python
+        class MyMetric(Metric):
+            counts: dict[str, int]  # "a=1,b=2" becomes {"a": 1, "b": 2}
+
+        MyMetric.model_validate({"counts": "a=1,b=2"}).counts  # -> {"a": 1, "b": 2}
+        MyMetric(counts={"a": 1, "b": 2}).model_dump()  # -> {"counts": "a=1,b=2"}
+        ```
+
+        Custom delimiters:
+
+        ```python
+        class MyMetric(Metric):
+            collection_delimiter = ";"
+            key_value_delimiter = ":"
+            counts: dict[str, int]  # "a:1;b:2" becomes {"a": 1, "b": 2}
+        ```
+
+        Optional values — individual values may be absent:
+
+        ```python
+        class MyMetric(Metric):
+            counts: dict[str, int | None]  # "a=,b=2" becomes {"a": None, "b": 2}
+        ```
+    """
+
+    key_value_delimiter: ClassVar[str] = "="
+    _handles_mappings: ClassVar[bool] = True

--- a/fgmetric/metric.py
+++ b/fgmetric/metric.py
@@ -8,12 +8,14 @@ from pydantic import BaseModel
 
 from fgmetric.converters import CounterPivotTable
 from fgmetric.converters import DelimitedCollection
+from fgmetric.converters import DelimitedMapping
 from fgmetric.converters import NullSentinels
 from fgmetric.metric_reader import MetricReader
 
 
 class Metric(
     DelimitedCollection,
+    DelimitedMapping,
     CounterPivotTable,
     NullSentinels,
     BaseModel,
@@ -38,10 +40,15 @@ class Metric(
     2. **Delimited collections.** Any field typed as `list[T]`, `set[T]`, `frozenset[T]`, or
        `tuple[...]` will be parsed from and serialized to a delimited string. The delimiter may be
        controlled by the `collection_delimiter` class variable.
+    3. **Delimited mappings.** Any field typed as `dict[K, V]` will be parsed from and serialized
+       to a delimited string of `key=value` pairs. The pair delimiter is `collection_delimiter`;
+       the key/value delimiter may be controlled by the `key_value_delimiter` class variable.
 
     Class Variables:
         collection_delimiter: A single-character delimiter used to split and join collection fields
-            during serialization/deserialization.
+            (and the pairs of mapping fields) during serialization/deserialization.
+        key_value_delimiter: A single-character delimiter used to split and join the keys and
+            values of mapping fields. Must differ from `collection_delimiter`. Defaults to `"="`.
         null_sentinels: The set of input strings that should be treated as `None` on Optional
             fields during validation. Defaults to `frozenset({""})`.
 

--- a/tests/test_delimited_collection.py
+++ b/tests/test_delimited_collection.py
@@ -2,7 +2,9 @@ from pathlib import Path
 from typing import Annotated
 
 import pytest
+from pydantic import BaseModel
 from pydantic import PlainSerializer
+from pydantic import ValidationError
 
 from fgmetric import Metric
 from fgmetric import MetricReader
@@ -193,6 +195,24 @@ def test_metric_is_built_on_delimited_collection() -> None:
 
     assert issubclass(Metric, DelimitedCollection)
     assert issubclass(FakeMetric, DelimitedCollection)
+
+
+def test_collection_handling_is_opt_in() -> None:
+    """A model mixing in only `DelimitedCollection` handles collections but not mappings."""
+
+    class CollectionOnly(DelimitedCollection, BaseModel):
+        tags: list[int]
+        counts: dict[str, int]
+
+    assert CollectionOnly._handles_collections
+    assert not CollectionOnly._handles_mappings
+
+    # The list field is split from a string; the dict field is left for Pydantic to handle, so a
+    # delimited string is not accepted as a dict.
+    m = CollectionOnly.model_validate({"tags": "1,2", "counts": {"a": 1}})
+    assert m.tags == [1, 2]
+    with pytest.raises(ValidationError):
+        CollectionOnly.model_validate({"tags": "1,2", "counts": "a=1"})
 
 
 def test_set_field_roundtrip() -> None:

--- a/tests/test_delimited_mapping.py
+++ b/tests/test_delimited_mapping.py
@@ -1,0 +1,206 @@
+from collections import Counter
+from enum import StrEnum
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+from pydantic import ValidationError
+
+from fgmetric import Metric
+from fgmetric import MetricReader
+from fgmetric import MetricWriter
+from fgmetric.converters import DelimitedMapping
+
+
+def test_metric_is_built_on_delimited_mapping() -> None:
+    """`DelimitedMapping` is mixed into `Metric`, so `dict` fields are supported by default."""
+
+    class FakeMetric(Metric):
+        counts: dict[str, int]
+
+    assert issubclass(Metric, DelimitedMapping)
+    assert FakeMetric._mapping_fieldnames == {"counts"}
+
+
+def test_mapping_handling_is_opt_in() -> None:
+    """A model mixing in only `DelimitedMapping` handles mappings but not collections."""
+
+    class MappingOnly(DelimitedMapping, BaseModel):
+        tags: list[int]
+        counts: dict[str, int]
+
+    assert MappingOnly._handles_mappings
+    assert not MappingOnly._handles_collections
+
+    # The dict field is split from a string; the list field is left for Pydantic to handle, so a
+    # delimited string is not accepted as a list.
+    m = MappingOnly.model_validate({"tags": [1, 2], "counts": "a=1"})
+    assert m.counts == {"a": 1}
+    with pytest.raises(ValidationError):
+        MappingOnly.model_validate({"tags": "1,2", "counts": "a=1"})
+
+
+def test_dict_field_roundtrip() -> None:
+    """A dict[K, V] field parses from and serializes to a delimited string of pairs."""
+
+    class FakeMetric(Metric):
+        counts: dict[str, int]
+
+    m = FakeMetric.model_validate({"counts": "a=1,b=2"})
+    assert m.counts == {"a": 1, "b": 2}
+    assert m.model_dump()["counts"] == "a=1,b=2"
+
+
+def test_dict_field_coerces_key_and_value_types() -> None:
+    """Keys and values are validated as the declared types."""
+
+    class FakeMetric(Metric):
+        counts: dict[int, float]
+
+    m = FakeMetric.model_validate({"counts": "1=1.5,2=2.5"})
+    assert m.counts == {1: 1.5, 2: 2.5}
+    assert all(isinstance(k, int) for k in m.counts)
+
+
+def test_dict_field_preserves_insertion_order() -> None:
+    """Dict serialization preserves insertion order (unlike unordered sets)."""
+
+    class FakeMetric(Metric):
+        counts: dict[str, int]
+
+    m = FakeMetric(counts={"z": 1, "a": 2, "m": 3})
+    assert m.model_dump()["counts"] == "z=1,a=2,m=3"
+
+
+def test_empty_dict_field() -> None:
+    """An empty cell parses to an empty dict and serializes back to an empty cell."""
+
+    class FakeMetric(Metric):
+        counts: dict[str, int]
+
+    m = FakeMetric.model_validate({"counts": ""})
+    assert m.counts == {}
+    assert m.model_dump()["counts"] == ""
+
+
+def test_optional_dict_field() -> None:
+    """An optional dict field treats an empty cell as None."""
+
+    class FakeMetric(Metric):
+        counts: dict[str, int] | None
+
+    assert FakeMetric.model_validate({"counts": ""}).counts is None
+    assert FakeMetric.model_validate({"counts": "a=1"}).counts == {"a": 1}
+    assert FakeMetric(counts=None).model_dump()["counts"] is None
+
+
+def test_dict_field_with_optional_values() -> None:
+    """A dict[K, V | None] field maps empty values to None."""
+
+    class FakeMetric(Metric):
+        counts: dict[str, int | None]
+
+    m = FakeMetric.model_validate({"counts": "a=,b=2"})
+    assert m.counts == {"a": None, "b": 2}
+    assert m.model_dump()["counts"] == "a=,b=2"
+
+
+def test_dict_field_with_custom_key_value_delimiter() -> None:
+    """The key/value delimiter is configurable."""
+
+    class FakeMetric(Metric):
+        key_value_delimiter = ":"
+        counts: dict[str, int]
+
+    m = FakeMetric.model_validate({"counts": "a:1,b:2"})
+    assert m.counts == {"a": 1, "b": 2}
+    assert m.model_dump()["counts"] == "a:1,b:2"
+
+
+def test_dict_field_with_custom_collection_delimiter() -> None:
+    """The pair delimiter is shared with collections via `collection_delimiter`."""
+
+    class FakeMetric(Metric):
+        collection_delimiter = ";"
+        counts: dict[str, int]
+
+    m = FakeMetric.model_validate({"counts": "a=1;b=2"})
+    assert m.counts == {"a": 1, "b": 2}
+    assert m.model_dump()["counts"] == "a=1;b=2"
+
+
+def test_dict_value_may_contain_key_value_delimiter() -> None:
+    """Only the first key/value delimiter splits a pair, so values may contain it."""
+
+    class FakeMetric(Metric):
+        counts: dict[str, str]
+
+    m = FakeMetric.model_validate({"counts": "url=http://x=y"})
+    assert m.counts == {"url": "http://x=y"}
+
+
+def test_dict_field_raises_on_malformed_pair() -> None:
+    """A pair missing the key/value delimiter raises a clear error."""
+
+    class FakeMetric(Metric):
+        counts: dict[str, int]
+
+    with pytest.raises(ValueError, match="key/value pair"):
+        FakeMetric.model_validate({"counts": "a=1,b"})
+
+
+def test_dict_field_file_roundtrip(tmp_path: Path) -> None:
+    """A dict field reads from and writes to a delimited file."""
+
+    class FakeMetric(Metric):
+        name: str
+        counts: dict[str, int]
+
+    fpath = tmp_path / "test.txt"
+    with fpath.open("w") as fout:
+        fout.write("name\tcounts\n")
+        fout.write("Nils\ta=1,b=2\n")
+
+    with MetricReader.open(FakeMetric, fpath) as reader:
+        metrics = list(reader)
+
+    assert metrics == [FakeMetric(name="Nils", counts={"a": 1, "b": 2})]
+
+    out = tmp_path / "out.txt"
+    writer: MetricWriter[FakeMetric]
+    with MetricWriter.open(FakeMetric, out) as writer:
+        writer.writeall(metrics)
+
+    assert out.read_text() == "name\tcounts\nNils\ta=1,b=2\n"
+
+
+def test_raises_if_key_value_delimiter_not_single_char() -> None:
+    """A multi-character key/value delimiter is rejected at class-definition time."""
+    with pytest.raises(ValueError, match="key_value_delimiter must be a single character"):
+
+        class FakeMetric(Metric):
+            key_value_delimiter = "::"
+            counts: dict[str, int]
+
+
+def test_raises_if_key_value_delimiter_equals_collection_delimiter() -> None:
+    """The two delimiters must differ, else pairs cannot be unambiguously split."""
+    with pytest.raises(ValueError, match="must differ"):
+
+        class FakeMetric(Metric):
+            collection_delimiter = ":"
+            key_value_delimiter = ":"
+            counts: dict[str, int]
+
+
+def test_counter_is_not_treated_as_a_mapping() -> None:
+    """A `Counter` field is handled by `CounterPivotTable`, not `DelimitedMapping`."""
+
+    class Color(StrEnum):
+        RED = "red"
+        BLUE = "blue"
+
+    class FakeMetric(Metric):
+        counts: Counter[Color]
+
+    assert FakeMetric._mapping_fieldnames == set()


### PR DESCRIPTION
## Summary

This PR is the final in a stack to expand `Metric`'s collection parsing behavior to support `tuple`, `set`, and `dict` along with the existing `list` support, to provide parity with fgpyo.

Adds a `DelimitedMapping` mixin that reads/writes `dict[K, V]` fields as delimited `key=value` pairs, and wires it into `Metric` so dict fields work by default (a la fgpyo). 

## Related Stack

- #80 
- #81 
- #82 
- #83
- #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DelimitedMapping` converter for serializing dictionary fields as delimited key=value pairs with configurable delimiter.

* **Tests**
  * Added comprehensive test suite covering mapping serialization, deserialization, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->