### PR TITLE
ci: add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Batch all action bumps into a single PR to reduce noise.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    # `chore(deps)` is skipped by git-cliff's default changelog config.
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary

Add `.github/dependabot.yml` so the repo's GitHub Actions stay current. All workflow actions are pinned to commit SHAs. Dependabot will open weekly PRs moving each pin to the latest release's SHA. All action bumps are batched into one grouped PR per week.