### PR TITLE
ci: add Dependabot config for Python (uv) dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,29 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+
+  # Python dependencies (uv) — reads pyproject.toml + uv.lock.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Library: only raise a constraint when the new locked version falls
+    # outside the existing range. Keeps the `>=` floors on runtime deps
+    # (pydantic, xopen) loose while still bumping the `==`-pinned dev tools.
+    versioning-strategy: "increase-if-necessary"
+    # Benchmark deps are test-only; freeze them rather than auto-bumping.
+    ignore:
+      - dependency-name: "pytest-benchmark"
+      - dependency-name: "fgpyo"
+    groups:
+      python-runtime:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      python-dev:
+        dependency-type: "development"
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -5,7 +5,7 @@
 On example files with 10,000 and 100,000 rows, fgmetric's Pydantic-based validation is ~5x faster than fgpyo's reflection-based approach.
 
 ```console
-$ uv run --extra benchmark poe benchmark
+$ uv run --group benchmark poe benchmark
 
 --------------------------------------------------------------------------- benchmark 'num_rows=1e4': 2 tests ----------------------------------------------------------------------------
 Name (time in ms)           Min                 Max                Mean            StdDev              Median               IQR            Outliers      OPS            Rounds  Iterations
@@ -27,7 +27,7 @@ test_fgpyo[1e5]        2,764.4992 (5.04)     2,790.0149 (4.81)     2,775.1369 (4
 To run the benchmarks yourself:
 
 ```console
-uv run --extra benchmark poe benchmark
+uv run --group benchmark poe benchmark
 ```
 
-This requires the `benchmark` optional dependency group, which includes `pytest-benchmark` and `fgpyo`.
+This requires the `benchmark` dependency group, which includes `pytest-benchmark` and `fgpyo`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,6 @@ dev = [
 ipython = [
     "ipython ~=9.2",
 ]
-
-[project.optional-dependencies]
 benchmark = [
     "pytest-benchmark ~=5.1.0",
     "fgpyo ~=1.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -157,13 +157,11 @@ dependencies = [
     { name = "xopen" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 benchmark = [
     { name = "fgpyo" },
     { name = "pytest-benchmark" },
 ]
-
-[package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "poethepoet" },
@@ -179,14 +177,15 @@ ipython = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fgpyo", marker = "extra == 'benchmark'", specifier = "~=1.2.0" },
     { name = "pydantic", specifier = ">=2.11.4" },
-    { name = "pytest-benchmark", marker = "extra == 'benchmark'", specifier = "~=5.1.0" },
     { name = "xopen", specifier = ">=2.0.0" },
 ]
-provides-extras = ["benchmark"]
 
 [package.metadata.requires-dev]
+benchmark = [
+    { name = "fgpyo", specifier = "~=1.2.0" },
+    { name = "pytest-benchmark", specifier = "~=5.1.0" },
+]
 dev = [
     { name = "mypy", specifier = "==1.18.2" },
     { name = "poethepoet", specifier = "~=0.34" },


### PR DESCRIPTION
## Summary

Stacked on #88. Extends Dependabot to cover Python dependencies.

Runtime and dev dependencies update in separate weekly grouped PRs. 

This PR also moves `benchmark` from `[project.optional-dependencies]` to a PEP 735 `[dependency-groups]` entry — it's test-only, never shipped or used in CI, and the group lets Dependabot classify it as *development*. 

> [!NOTE]
> Based on #88; review that one first. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark instructions to use the latest command format.
  * Clarified which dependencies are included for benchmark runs.

* **Chores**
  * Expanded automated dependency update coverage for Python packages.
  * Improved how dependency updates are grouped and labeled for cleaner maintenance updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->